### PR TITLE
Determine readylog path at runtime from environment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,10 +206,6 @@ if (${ECLIPSE_FOUND})
 	option(BUILD_READYLOG_IMPL "Build the readylog semantics (ECLiPSe Prolog)" ON)
 endif()
 if (${BUILD_READYLOG_IMPL})
-	find_file(READYLOG_PL preprocessor.pl
-		PATHS ${CMAKE_CURRENT_SOURCE_DIR}/../
-		PATH_SUFFIXES /readylog/interpreter /kbsgolog/interpreters/readylog)
-
 	set(READYLOG_SRC
 		src/semantics/readylog/action.cpp
 		src/semantics/readylog/variable.cpp
@@ -231,10 +227,9 @@ if (${BUILD_READYLOG_IMPL})
 
 	link_directories(${ECLIPSE_LIBRARY_DIRS})
 	add_library(readylog++ SHARED ${READYLOG_SRC})
-	target_compile_definitions(readylog++ PRIVATE -DREADYLOG_PATH=\"${READYLOG_PL}\")
 	target_compile_definitions(readylog++ PUBLIC -DECLIPSE_DIR=\"${ECLIPSE_DIR}\" -DUSES_NO_ENGINE_HANDLE)
 	target_include_directories(readylog++ PUBLIC ${ECLIPSE_INCLUDE_DIRS})
-	target_link_libraries(readylog++ golog++ ${ECLIPSE_LIBRARIES})
+	target_link_libraries(readylog++ golog++ ${ECLIPSE_LIBRARIES} stdc++fs)
 	set_property(TARGET readylog++ PROPERTY CXX_STANDARD 14)
 	set_property(TARGET readylog++ PROPERTY SOVERSION ${GOLOGPP_VERSION})
 	install(TARGETS readylog++ DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/src/semantics/readylog/execution.h
+++ b/src/semantics/readylog/execution.h
@@ -45,6 +45,7 @@ private:
     ReadylogContext(const eclipse_opts &options, unique_ptr<PlatformBackend> &&exec_backend);
 
     virtual void compile_term(const EC_word &term);
+    std::string find_readylog();
 
 	EC_ref *ec_start_;
 	int last_rv_;


### PR DESCRIPTION
Parse the environment variable READYLOG_PL like a PATH, i.e., split the
path at each ':' and check if the preprocessor is in any of those paths.
If so, use that as the path for ReadyLog.

If ReadyLog cannot be found, throw a std::runtime_error.