### PR TITLE
Fix undefined template symbols

### DIFF
--- a/src/model/value.cpp
+++ b/src/model/value.cpp
@@ -113,32 +113,6 @@ Value::Value(Representation &&l)
 {}
 
 
-template<class ReprT>
-Value::Value(const string &type_name, ReprT repr)
-: representation_(repr)
-{
-	set_type_by_name(type_name);
-}
-
-template
-Value::Value(const string &type_name, const string &);
-
-template
-Value::Value(const string &type_name, string);
-
-template
-Value::Value(const string &type_name, bool);
-
-template
-Value::Value(const string &type_name, int);
-
-template
-Value::Value(const string &type_name, long);
-
-template
-Value::Value(const string &type_name, double);
-
-
 Value::Value(const string &type_name, const vector<fusion_wtf_vector<string, Value *>> &compound_values)
 {
 	set_type_by_name(type_name);

--- a/src/model/value.h
+++ b/src/model/value.h
@@ -49,7 +49,7 @@ class Value
 {
 public:
 	using Representation = boost::variant <
-		int, long, double, // NumberType
+		unsigned int, int, unsigned long, long, double, // NumberType
 		string, // StringType, SymbolType
 		bool, // BoolType
 		CompoundType::Representation,

--- a/src/model/value.h
+++ b/src/model/value.h
@@ -57,7 +57,9 @@ public:
 	>;
 
 	template<class ReprT>
-	Value(const string &type_name, ReprT repr);
+	explicit Value(const string &type_name, ReprT repr) : representation_(repr) {
+		set_type_by_name(type_name);
+	}
 
 	Value(const string &type_name, const vector<fusion_wtf_vector<string, Value *>> &compound_values);
 	Value(const string &type_name, const boost::optional<vector<Value *>> &list_values);


### PR DESCRIPTION
Declaring each possible constructor is error-prone and results in
undefined symbols if a template variant is forgotten. Instead, just move
the constructor into the header, where templated constructors belong.

Also make the constructor explicit to avoid undesired implicit
conversions.

Also add support for unsigned int variants as Values (`unsigned int` and `unsigned long`).