### PR TITLE
model: simplify backend interaction

### DIFF
--- a/src/model/activity.cpp
+++ b/src/model/activity.cpp
@@ -44,7 +44,7 @@ Activity::State Activity::target_state(Transition::Hook hook)
 }
 
 
-void Activity::update(Transition::Hook hook, Value *sensing_result)
+void Activity::update(Transition::Hook hook, boost::optional<Value> &&sensing_result)
 {
 	PlatformBackend::Lock backend_lock = exec_context_.backend().lock();
 
@@ -61,7 +61,7 @@ void Activity::update(Transition::Hook hook, Value *sensing_result)
 			);
 		else if (sensing_result) {
 			sensing_result->attach_semantics(exec_context_.semantics_factory());
-			set_sensing_result(sensing_result);
+			set_sensing_result(std::forward<boost::optional<Value>>(sensing_result));
 		}
 	}
 
@@ -101,13 +101,13 @@ void Activity::attach_semantics(SemanticsFactory &implementor)
 	}
 }
 
-void Activity::set_sensing_result(Value *sr)
-{ sensing_result_.reset(sr); }
+void Activity::set_sensing_result(boost::optional<Value> &&sr)
+{ sensing_result_ = std::forward<boost::optional<Value>>(sr); }
 
-unique_ptr<Value> &Activity::sensing_result()
+boost::optional<Value> &Activity::sensing_result()
 { return sensing_result_; }
 
-const unique_ptr<Value> &Activity::sensing_result() const
+const boost::optional<Value> &Activity::sensing_result() const
 { return sensing_result_; }
 
 

--- a/src/model/activity.h
+++ b/src/model/activity.h
@@ -6,6 +6,8 @@
 #include "action.h"
 #include "transition.h"
 
+#include <boost/optional.hpp>
+
 
 namespace gologpp {
 
@@ -23,7 +25,7 @@ public:
 	State state() const;
 	void set_state(State s);
 
-	void update(Transition::Hook hook, Value *sensing_result = nullptr);
+	void update(Transition::Hook hook, boost::optional<Value> &&sensing_result = {});
 
 	const std::string &mapped_name() const;
 	Value mapped_arg_value(const string &name) const;
@@ -32,15 +34,15 @@ public:
 
 	virtual void attach_semantics(SemanticsFactory &) override;
 
-	void set_sensing_result(Value *);
-	unique_ptr<Value> &sensing_result();
-	const unique_ptr<Value> &sensing_result() const;
+	void set_sensing_result(boost::optional<Value> &&);
+	boost::optional<Value> &sensing_result();
+	const boost::optional<Value> &sensing_result() const;
 
 	static State target_state(Transition::Hook);
 
 private:
 	State state_;
-	unique_ptr<Value> sensing_result_;
+	boost::optional<Value> sensing_result_;
 	AExecutionContext &exec_context_;
 };
 

--- a/src/model/activity.h
+++ b/src/model/activity.h
@@ -10,17 +10,20 @@
 namespace gologpp {
 
 
-class Activity : public Grounding<Action>, public LanguageElement<Activity> {
+class Activity
+: public Grounding<Action>
+, public LanguageElement<Activity>
+, public std::enable_shared_from_this<Activity> {
 public:
 	enum State { IDLE, RUNNING, FINAL, PREEMPTED, FAILED };
 
-	Activity(const shared_ptr<Action> &action, vector<unique_ptr<Value>> &&args, State state = IDLE);
-	Activity(const shared_ptr<Transition> &);
+	Activity(const shared_ptr<Action> &action, vector<unique_ptr<Value>> &&args, AExecutionContext &, State state = IDLE);
+	Activity(const shared_ptr<Transition> &, AExecutionContext &);
 
 	State state() const;
 	void set_state(State s);
 
-	shared_ptr<Transition> transition(Transition::Hook hook);
+	void update(Transition::Hook hook, Value *sensing_result = nullptr);
 
 	const std::string &mapped_name() const;
 	Value mapped_arg_value(const string &name) const;
@@ -33,9 +36,12 @@ public:
 	unique_ptr<Value> &sensing_result();
 	const unique_ptr<Value> &sensing_result() const;
 
+	static State target_state(Transition::Hook);
+
 private:
 	State state_;
 	unique_ptr<Value> sensing_result_;
+	AExecutionContext &exec_context_;
 };
 
 

--- a/src/model/execution.cpp
+++ b/src/model/execution.cpp
@@ -59,8 +59,8 @@ bool AExecutionContext::exog_empty()
 SemanticsFactory &AExecutionContext::semantics_factory()
 { return *semantics_; }
 
-unique_ptr<PlatformBackend> &AExecutionContext::backend()
-{ return platform_backend_;}
+PlatformBackend &AExecutionContext::backend()
+{ return *platform_backend_;}
 
 
 
@@ -85,7 +85,7 @@ History ExecutionContext::run(Block &&program)
 	compile(program);
 
 	while (!final(program, history)) {
-		context_time_ = backend()->time();
+		context_time_ = backend().time();
 		while (!exog_empty()) {
 			shared_ptr<Grounding<AbstractAction>> exog = exog_queue_pop();
 			std::cout << ">>> Exogenous event: " << exog << std::endl;
@@ -98,13 +98,13 @@ History ExecutionContext::run(Block &&program)
 			if (trans) {
 				std::cout << "<<< trans: " << trans->str() << std::endl;
 				if (trans->hook() == Transition::Hook::STOP)
-					backend()->preempt_activity(trans);
+					backend().preempt_activity(trans);
 				else if (trans->hook() == Transition::Hook::START)
-					backend()->start_activity(trans);
+					backend().start_activity(trans);
 				else if (trans->hook() == Transition::Hook::FINISH && trans->target()->senses())
-					history.abstract_impl().append_sensing_result(backend()->end_activity(trans));
+					history.abstract_impl().append_sensing_result(backend().end_activity(trans));
 				else
-					backend()->end_activity(trans);
+					backend().end_activity(trans);
 			}
 		}
 		else {

--- a/src/model/execution.h
+++ b/src/model/execution.h
@@ -47,7 +47,7 @@ public:
 
 	SemanticsFactory &semantics_factory();
 
-	unique_ptr<PlatformBackend> &backend();
+	PlatformBackend &backend();
 
 private:
 	std::mutex exog_mutex_;

--- a/src/model/platform_backend.h
+++ b/src/model/platform_backend.h
@@ -33,18 +33,15 @@ struct Clock {
 
 class PlatformBackend {
 public:
-	using ActivitySet = std::unordered_set<
-		shared_ptr<Grounding<Action>>,
-		Grounding<Action>::Hash,
-		Grounding<Action>::Equals
-	>;
+	using ActivitySet = std::unordered_set<shared_ptr<Grounding<Action>>>;
+	using Lock = std::unique_lock<std::mutex>;
+
 	virtual ~PlatformBackend();
 
 	shared_ptr<Activity> end_activity(shared_ptr<Transition>);
 	void start_activity(shared_ptr<Transition>);
 	virtual void preempt_activity(shared_ptr<Transition>) = 0;
-
-	void update_activity(shared_ptr<Transition>, Value *sensing_result = nullptr);
+	Lock lock();
 
 	virtual Clock::time_point time() const noexcept = 0;
 	void set_context(AExecutionContext *ctx);
@@ -84,8 +81,7 @@ private:
 	};
 
 	std::unordered_map<
-		shared_ptr<Grounding<Action>>, shared_ptr<ActivityThread>,
-		Grounding<Action>::Hash, Grounding<Action>::Equals
+		shared_ptr<Grounding<Action>>, shared_ptr<ActivityThread>
 	> activity_threads_;
 };
 

--- a/src/model/reference.h
+++ b/src/model/reference.h
@@ -276,21 +276,6 @@ public:
 			ReferenceBase<TargetT, Value>::attach_semantics(f);
 		}
 	}
-
-
-	struct Hash {
-		std::size_t operator () (const shared_ptr<Grounding<TargetT>> &t) const
-		{ return t->hash(); }
-	};
-
-
-	struct Equals {
-		bool operator () (
-			const shared_ptr<Grounding<TargetT>> &lhs,
-			const shared_ptr<Grounding<TargetT>> &rhs
-		) const
-		{ return *lhs == *rhs; }
-	};
 };
 
 
@@ -376,12 +361,18 @@ private:
 
 namespace std {
 
+
 template<class TargetT>
 struct hash<gologpp::Reference<TargetT>> {
 	size_t operator () (const gologpp::Reference<TargetT> &o) const
 	{ return o.hash(); }
 };
 
+template<class TargetT>
+struct hash<gologpp::Reference<TargetT> *> {
+	size_t operator () (const gologpp::Reference<TargetT> *o) const
+	{ return o->hash(); }
+};
 
 template<class TargetT>
 struct hash<gologpp::unique_ptr<gologpp::Reference<TargetT>>> {
@@ -390,10 +381,76 @@ struct hash<gologpp::unique_ptr<gologpp::Reference<TargetT>>> {
 };
 
 template<class TargetT>
+struct hash<gologpp::shared_ptr<gologpp::Reference<TargetT>>> {
+	size_t operator () (const gologpp::shared_ptr<gologpp::Reference<TargetT>> &o) const
+	{ return o->hash(); }
+};
+
+template<class TargetT>
 struct equal_to<gologpp::unique_ptr<gologpp::Reference<TargetT>>> {
 	bool operator () (
 		const gologpp::unique_ptr<gologpp::Reference<TargetT>> &lhs,
 		const gologpp::unique_ptr<gologpp::Reference<TargetT>> &rhs
+	) const {
+		return *lhs == *rhs;
+	}
+};
+
+template<class TargetT>
+struct equal_to<gologpp::shared_ptr<gologpp::Reference<TargetT>>> {
+	bool operator () (
+		const gologpp::shared_ptr<gologpp::Reference<TargetT>> &lhs,
+		const gologpp::shared_ptr<gologpp::Reference<TargetT>> &rhs
+	) const {
+		return *lhs == *rhs;
+	}
+};
+
+template<class TargetT>
+struct equal_to<gologpp::Reference<TargetT> *> {
+	bool operator () (
+		const gologpp::Reference<TargetT> *lhs,
+		const gologpp::Reference<TargetT> *rhs
+	) const {
+		return *lhs == *rhs;
+	}
+};
+
+
+template<class TargetT>
+struct hash<gologpp::Grounding<TargetT>> {
+	size_t operator () (const gologpp::Grounding<TargetT> &o) const
+	{ return o.hash(); }
+};
+
+template<class TargetT>
+struct hash<gologpp::unique_ptr<gologpp::Grounding<TargetT>>> {
+	size_t operator () (const gologpp::unique_ptr<gologpp::Grounding<TargetT>> &o) const
+	{ return o->hash(); }
+};
+
+template<class TargetT>
+struct hash<gologpp::shared_ptr<gologpp::Grounding<TargetT>>> {
+	size_t operator () (const gologpp::shared_ptr<gologpp::Grounding<TargetT>> &o) const
+	{ return o->hash(); }
+};
+
+
+template<class TargetT>
+struct equal_to<gologpp::unique_ptr<gologpp::Grounding<TargetT>>> {
+	bool operator () (
+		const gologpp::unique_ptr<gologpp::Grounding<TargetT>> &lhs,
+		const gologpp::unique_ptr<gologpp::Grounding<TargetT>> &rhs
+	) const {
+		return *lhs == *rhs;
+	}
+};
+
+template<class TargetT>
+struct equal_to<gologpp::shared_ptr<gologpp::Grounding<TargetT>>> {
+	bool operator () (
+		const gologpp::shared_ptr<gologpp::Grounding<TargetT>> &lhs,
+		const gologpp::shared_ptr<gologpp::Grounding<TargetT>> &rhs
 	) const {
 		return *lhs == *rhs;
 	}

--- a/src/semantics/readylog/action.cpp
+++ b/src/semantics/readylog/action.cpp
@@ -153,7 +153,7 @@ EC_word Semantics<Activity>::plterm()
 
 	return ::term(EC_functor("exog_state_change", 3),
 		Semantics<Grounding<Action>>::plterm(),
-		EC_word(ReadylogContext::instance().backend()->time().time_since_epoch().count()),
+		EC_word(ReadylogContext::instance().backend().time().time_since_epoch().count()),
 		EC_atom(state.c_str())
 	);
 }
@@ -192,7 +192,7 @@ EC_word Semantics<Transition>::plterm()
 
 	return ::term(EC_functor(name.c_str(), 2),
 		Semantics<Grounding<Action>>::plterm(),
-		EC_word(ReadylogContext::instance().backend()->time().time_since_epoch().count())
+		EC_word(ReadylogContext::instance().backend().time().time_since_epoch().count())
 	);
 }
 


### PR DESCRIPTION
The `Activity` should clearly be capable of managing its own state. Keeping it completely separated from the execution concern was over-engineered: An `Activity` by its very nature links together the runtime state and the code model. Now that it has access to its `ExecutionContext`, all a platform integrator needs to do is call `Activity::update(...)` to notify golog++ of the end (result) of a running action.