### PR TITLE
the during() construct

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,7 @@ set(INTERFACE_SRC
 	src/model/types.cpp
 	src/model/compound_expression.cpp
 	src/model/list_expression.cpp
+	src/model/semantics.cpp
 )
 add_library(golog++ SHARED ${INTERFACE_SRC})
 target_compile_options(golog++ PUBLIC -fPIC)

--- a/src/model/activity.cpp
+++ b/src/model/activity.cpp
@@ -50,8 +50,8 @@ Activity::State Activity::target_state(Transition::Hook hook)
 	switch (hook) {
 	case Transition::Hook::START:
 		return Activity::State::RUNNING;
-	case Transition::Hook::STOP:
-		return Activity::State::PREEMPTED;
+	case Transition::Hook::CANCEL:
+		return Activity::State::CANCELLED;
 	case Transition::Hook::FINISH:
 		return Activity::State::FINAL;
 	case Transition::Hook::FAIL:
@@ -129,7 +129,7 @@ string to_string(Activity::State s)
 		return "idle";
 	case Activity::State::RUNNING:
 		return "running";
-	case Activity::State::PREEMPTED:
+	case Activity::State::CANCELLED:
 		return "preempted";
 	case Activity::State::FINAL:
 		return "final";

--- a/src/model/activity.cpp
+++ b/src/model/activity.cpp
@@ -56,6 +56,8 @@ Activity::State Activity::target_state(Transition::Hook hook)
 		return Activity::State::FINAL;
 	case Transition::Hook::FAIL:
 		return Activity::State::FAILED;
+	case Transition::Hook::END:
+		return Activity::State::IDLE;
 	}
 	throw Bug("Unhandled Transition hook. Ignored warnings when compiling?");
 }

--- a/src/model/activity.h
+++ b/src/model/activity.h
@@ -34,7 +34,7 @@ class Activity
 , public LanguageElement<Activity>
 , public std::enable_shared_from_this<Activity> {
 public:
-	enum State { IDLE, RUNNING, FINAL, PREEMPTED, FAILED };
+	enum State { IDLE, RUNNING, FINAL, CANCELLED, FAILED };
 
 	Activity(const shared_ptr<Action> &action, vector<unique_ptr<Value>> &&args, AExecutionContext &, State state = IDLE);
 	Activity(const shared_ptr<Transition> &, AExecutionContext &);

--- a/src/model/execution.cpp
+++ b/src/model/execution.cpp
@@ -132,7 +132,7 @@ void ExecutionContext::run(Block &&program)
 			shared_ptr<Transition> trans = history().abstract_semantics().get_last_transition();
 			if (trans) {
 				std::cout << "<<< trans: " << trans->str() << std::endl;
-				if (trans->hook() == Transition::Hook::STOP)
+				if (trans->hook() == Transition::Hook::CANCEL)
 					backend().preempt_activity(trans);
 				else if (trans->hook() == Transition::Hook::START)
 					backend().start_activity(trans);

--- a/src/model/gologpp.h
+++ b/src/model/gologpp.h
@@ -106,6 +106,7 @@ class ListAccess;
 class ListLength;
 class ListPop;
 class ListPush;
+class During;
 
 class Function;
 
@@ -159,6 +160,7 @@ class PlatformBackend;
 	(Scope)(ArithmeticOperation) \
 	(Negation)(BooleanOperation)(Quantification)(Concurrent) \
 	(Block)(Choose)(Conditional)(Search)(Solve)(Test)(While) \
+	(During) \
 	(History)(Reference<Action>) \
 	(Reference<ExogAction>) \
 	(StringConcatenation) \

--- a/src/model/gologpp.h
+++ b/src/model/gologpp.h
@@ -159,8 +159,7 @@ class PlatformBackend;
 	(Scope)(ArithmeticOperation) \
 	(Negation)(BooleanOperation)(Quantification)(Concurrent) \
 	(Block)(Choose)(Conditional)(Search)(Solve)(Test)(While) \
-	(History)(Reference<Action>)(Grounding<Action>) \
-	(Grounding<ExogAction>) \
+	(History)(Reference<Action>) \
 	(Reference<ExogAction>) \
 	(StringConcatenation) \
 	(ToString) \

--- a/src/model/platform_backend.cpp
+++ b/src/model/platform_backend.cpp
@@ -61,12 +61,22 @@ shared_ptr<Activity> PlatformBackend::end_activity(shared_ptr<Transition> trans)
 	if (!dur_running)
 		throw LostTransition(trans->str());
 
-	if (dur_running->state() != Activity::target_state(trans->hook()))
-			throw InconsistentTransition(trans->str());
-
-	activities_.erase(it);
-
-	return dur_running;
+	// Either the durative action's state exactly matches the primitive action's hook,
+	// or the hook is END, which may be executed if the durative state is either FINAL, FAILED or CANCELLED
+	if ((trans->hook() == Transition::Hook::END
+			&& (
+				dur_running->state() == Activity::State::FINAL
+				|| dur_running->state() == Activity::State::FAILED
+				|| dur_running->state() == Activity::State::CANCELLED
+			)
+		)
+		|| dur_running->state() == Activity::target_state(trans->hook())
+	) {
+		activities_.erase(it);
+		return dur_running;
+	}
+	else
+		throw InconsistentTransition(trans->str());
 }
 
 

--- a/src/model/platform_backend.cpp
+++ b/src/model/platform_backend.cpp
@@ -88,7 +88,7 @@ void DummyBackend::ActivityThread::end_activity(std::chrono::duration<double> wh
 
 	if (canceled) {
 		std::cout << "DummyBackend: Activity " << a->str() << " STOPPED" << std::endl;
-		a->update(Transition::Hook::STOP);
+		a->update(Transition::Hook::CANCEL);
 	}
 	else {
 		std::cout << "DummyBackend: Activity " << a->str() << " FINAL" << std::endl;

--- a/src/model/procedural.cpp
+++ b/src/model/procedural.cpp
@@ -513,6 +513,58 @@ string ListPush::to_string(const string &pfx) const
 
 
 
+During::During(
+	Reference<Action> *action_call,
+	Expression *parallel_block,
+	boost::optional<Expression *> on_fail,
+	boost::optional<Expression *> on_cancel
+)
+: action_call_(action_call)
+, parallel_block_(parallel_block)
+, on_fail_(on_fail.get_value_or(
+	new Block(
+		new Scope(parallel_block->scope().parent_scope()),
+		{}
+	)
+  ))
+, on_cancel_(on_cancel.get_value_or(
+	new Block(
+		new Scope(parallel_block->scope().parent_scope()),
+		{}
+	)
+  ))
+{
+	action_call_->set_parent(this);
+	parallel_block_->set_parent(this);
+	on_fail_->set_parent(this);
+	on_cancel_->set_parent(this);
+}
+
+const Reference<Action> &During::action_call() const
+{ return *action_call_; }
+
+const Expression &During::parallel_block() const
+{ return *parallel_block_; }
+
+const Expression &During::on_fail() const
+{ return *on_fail_; }
+
+const Expression &During::on_cancel() const
+{ return *on_cancel_; }
+
+string During::to_string(const string &pfx) const
+{
+	return pfx + "during (" + action_call().str() + ")\n"
+		+ parallel_block().to_string(pfx)
+		+ "on_fail " + on_fail().to_string(pfx)
+		+ "on_cancel " + on_cancel().to_string(pfx)
+	;
+}
+
+
+
+
+
 
 } // namespace gologpp
 

--- a/src/model/procedural.cpp
+++ b/src/model/procedural.cpp
@@ -391,23 +391,6 @@ string DurativeCall::to_string(const string &pfx) const
 
 
 
-string to_string(DurativeCall::Hook hook)
-{
-	switch (hook) {
-	case DurativeCall::Hook::START:
-		return "start";
-	case DurativeCall::Hook::FINISH:
-		return "finish";
-	case DurativeCall::Hook::FAIL:
-		return "fail";
-	case DurativeCall::Hook::STOP:
-		return "stop";
-	}
-	throw Bug(string("Unhandled ") + typeid(hook).name());
-}
-
-
-
 FieldAccess::FieldAccess(Expression *subject, const string &field_name)
 : subject_(subject)
 , field_name_(field_name)

--- a/src/model/procedural.h
+++ b/src/model/procedural.h
@@ -490,6 +490,34 @@ private:
 
 
 
+class During
+: public Expression
+, public NoScopeOwner
+, public LanguageElement<During, VoidType>
+{
+public:
+	During(
+		Reference<Action> *action_call,
+		Expression *parallel_block,
+		boost::optional<Expression *> on_fail,
+		boost::optional<Expression *> on_cancel
+	);
+	const Reference<Action> &action_call() const;
+	const Expression &parallel_block() const;
+	const Expression &on_fail() const;
+	const Expression &on_cancel() const;
+
+	DEFINE_ATTACH_SEMANTICS_WITH_MEMBERS(*action_call_, *parallel_block_, *on_fail_, *on_cancel_)
+
+	string to_string(const string &pfx) const override;
+
+private:
+	unique_ptr<Reference<Action>> action_call_;
+	SafeExprOwner<VoidType> parallel_block_;
+	SafeExprOwner<VoidType> on_fail_;
+	SafeExprOwner<VoidType> on_cancel_;
+};
+
 } // namespace gologpp
 
 

--- a/src/model/procedural.h
+++ b/src/model/procedural.h
@@ -36,6 +36,7 @@
 #include "action.h"
 #include "reference.h"
 #include "fluent.h"
+#include "transition.h"
 
 namespace gologpp {
 
@@ -358,9 +359,7 @@ class DurativeCall
 , public LanguageElement<DurativeCall, VoidType>
 {
 public:
-	enum Hook {
-		START, FINISH, FAIL, STOP
-	};
+	using Hook = Transition::Hook;
 
 	DurativeCall(Hook hook, Reference<Action> *action);
 	DEFINE_ATTACH_SEMANTICS_WITH_MEMBERS(*action_)
@@ -373,9 +372,6 @@ private:
 	const Hook hook_;
 	const unique_ptr<Reference<Action>> action_;
 };
-
-
-string to_string(DurativeCall::Hook);
 
 
 

--- a/src/model/reference.h
+++ b/src/model/reference.h
@@ -198,13 +198,6 @@ public:
 	shared_ptr<const TargetT> target() const
 	{ return std::dynamic_pointer_cast<const TargetT>(target_.lock()); }
 
-
-	virtual void attach_semantics(SemanticsFactory &f) override
-	{
-		for (unique_ptr<ArgsT> &expr : args_)
-			expr->attach_semantics(f);
-	}
-
 	virtual string to_string(const string &pfx) const override
 	{ return pfx + name() + '(' + concat_list(args(), ", ", "") + ')'; }
 
@@ -248,7 +241,8 @@ public:
 	{
 		if (!this->semantics_) {
 			this->semantics_ = f.make_semantics(*this);
-			ReferenceBase<TargetT, Expression>::attach_semantics(f);
+			for (auto &arg : this->args())
+				arg->attach_semantics(f);
 		}
 	}
 };
@@ -299,15 +293,6 @@ public:
 
 	virtual const Scope &parent_scope() const override
 	{ return global_scope(); }
-
-
-	virtual void attach_semantics(SemanticsFactory &f) override
-	{
-		if (!this->semantics_) {
-			this->semantics_ = f.make_semantics(*this);
-			ReferenceBase<TargetT, Value>::attach_semantics(f);
-		}
-	}
 
 	virtual const ParamsToArgs<Value> &params_to_args() const override
 	{ return ReferenceBase<TargetT, Value>::params_to_args(); }

--- a/src/model/scope.cpp
+++ b/src/model/scope.cpp
@@ -216,8 +216,7 @@ void Scope::implement_globals(SemanticsFactory &implementor, AExecutionContext &
 	// Two loops since we want everything implemented before we attempt to compile anything.
 	// It's all connected, you know...
 	for (GlobalsMap::value_type &entry : *globals_)
-		std::dynamic_pointer_cast<AbstractLanguageElement>(entry.second)
-			->attach_semantics(implementor);
+		entry.second->attach_semantics(implementor);
 	for (GlobalsMap::value_type &entry : *globals_)
 		entry.second->compile(ctx);
 

--- a/src/model/semantics.cpp
+++ b/src/model/semantics.cpp
@@ -15,29 +15,17 @@
  * along with golog++.  If not, see <https://www.gnu.org/licenses/>.
 **************************************************************************/
 
-#include "reference.h"
-#include "variable.h"
+#include "semantics.h"
 
 namespace gologpp {
 
 
-Semantics<Reference<Variable>>::Semantics(const Reference<Variable> &ref)
-: AbstractSemantics<Reference<Variable>>(ref)
+AbstractSemantics<AbstractLanguageElement>::AbstractSemantics()
 {}
 
-EC_word Semantics<Reference<Variable>>::plterm()
-{ return element().target()->semantics().plterm(); }
 
-
-
-template<>
-EC_word Semantics<Reference<Action>>::plterm()
-{
-	return ::list(::term(EC_functor("start", 2), reference_term(element()), EC_atom("now")),
-		::list(::term(EC_functor("finish", 2), reference_term(element()), EC_atom("now")),
-			::nil()
-		)
-	);
 }
 
-} // namespace gologpp
+
+
+

--- a/src/model/semantics.h
+++ b/src/model/semantics.h
@@ -30,6 +30,7 @@ namespace gologpp {
 template<>
 class AbstractSemantics<AbstractLanguageElement> {
 public:
+	AbstractSemantics();
 	virtual ~AbstractSemantics<AbstractLanguageElement>() = default;
 
 	template<class GologT = AbstractLanguageElement>

--- a/src/model/transition.cpp
+++ b/src/model/transition.cpp
@@ -53,6 +53,8 @@ string to_string(Transition::Hook h)
 		return "finish";
 	case Transition::Hook::FAIL:
 		return "fail";
+	case Transition::Hook::END:
+		return "end";
 	}
 	throw Bug(string("Unhandled ") + typeid(h).name());
 }

--- a/src/model/transition.cpp
+++ b/src/model/transition.cpp
@@ -47,8 +47,8 @@ string to_string(Transition::Hook h)
 	switch (h) {
 	case Transition::Hook::START:
 		return "start";
-	case Transition::Hook::STOP:
-		return "stop";
+	case Transition::Hook::CANCEL:
+		return "cancel";
 	case Transition::Hook::FINISH:
 		return "finish";
 	case Transition::Hook::FAIL:

--- a/src/model/transition.h
+++ b/src/model/transition.h
@@ -28,7 +28,7 @@ namespace gologpp {
 
 class Transition : public Grounding<Action>, public LanguageElement<Transition> {
 public:
-	enum Hook { START, CANCEL, FINISH, FAIL };
+	enum Hook { START, CANCEL, FINISH, FAIL, END };
 
 	Transition(const shared_ptr<Action> &action, vector<unique_ptr<Value>> &&args, Hook hook);
 

--- a/src/model/transition.h
+++ b/src/model/transition.h
@@ -28,7 +28,7 @@ namespace gologpp {
 
 class Transition : public Grounding<Action>, public LanguageElement<Transition> {
 public:
-	enum Hook { START, STOP, FINISH, FAIL };
+	enum Hook { START, CANCEL, FINISH, FAIL };
 
 	Transition(const shared_ptr<Action> &action, vector<unique_ptr<Value>> &&args, Hook hook);
 

--- a/src/parser/statements.cpp
+++ b/src/parser/statements.cpp
@@ -185,7 +185,7 @@ StatementParser::StatementParser()
 	durative_call = (
 		( (
 			lit("start") [ _a = DurativeCall::Hook::START ]
-			| lit("stop") [ _a = DurativeCall::Hook::STOP ]
+			| lit("cancel") [ _a = DurativeCall::Hook::CANCEL ]
 			| lit("finish") [ _a = DurativeCall::Hook::FINISH ]
 			| lit("fail") [ _a = DurativeCall::Hook::FAIL ]
 		) >> "(" )

--- a/src/parser/statements.cpp
+++ b/src/parser/statements.cpp
@@ -28,6 +28,7 @@
 #include <boost/spirit/include/qi_lit.hpp>
 #include <boost/spirit/include/qi_list.hpp>
 #include <boost/spirit/include/qi_attr.hpp>
+#include <boost/spirit/include/qi_permutation.hpp>
 
 #include <boost/phoenix/object/new.hpp>
 #include <boost/phoenix/object/delete.hpp>
@@ -36,6 +37,7 @@
 #include <boost/phoenix/object/construct.hpp>
 #include <boost/phoenix/bind/bind_member_function.hpp>
 #include <boost/phoenix/bind/bind_function.hpp>
+#include <boost/phoenix/fusion/at.hpp>
 
 #include "types.h"
 #include "formula.h"
@@ -73,7 +75,9 @@ StatementParser::StatementParser()
 	compound_statement = block(_r1) | choose(_r1) | conditional(_r1)
 		| pick(_r1)
 		| solve(_r1) | search(_r1) | r_while(_r1)
-		| concurrent(_r1);
+		| concurrent(_r1)
+		| during(_r1)
+	;
 	compound_statement.name("compound_statement");
 
 	block = (lit('{') [
@@ -181,6 +185,18 @@ StatementParser::StatementParser()
 	];
 	return_stmt.name("return");
 
+	during = (
+		lit("during") > '(' > action_call(_r1) > ')'
+		> statement(_r1)
+		> (
+			("on_fail" > statement(_r1))
+			^ ("on_cancel" > statement(_r1))
+		)
+	) [
+		_val = new_<During>(_1, _2, at_c<0>(_3), at_c<1>(_3))
+	]
+	;
+
 
 	durative_call = (
 		( (
@@ -188,6 +204,7 @@ StatementParser::StatementParser()
 			| lit("cancel") [ _a = DurativeCall::Hook::CANCEL ]
 			| lit("finish") [ _a = DurativeCall::Hook::FINISH ]
 			| lit("fail") [ _a = DurativeCall::Hook::FAIL ]
+			| lit("end") [ _a = DurativeCall::Hook::END ]
 		) >> "(" )
 		> action_call(_r1) > ")"
 	) [

--- a/src/parser/statements.h
+++ b/src/parser/statements.h
@@ -50,6 +50,8 @@ struct StatementParser : grammar<Expression *(Scope &)> {
 	rule<ListPop *(Scope &), locals<ListOpEnd>> list_pop;
 	rule<ListPush *(Scope &), locals<ListOpEnd, Typename>> list_push;
 
+	rule<During *(Scope &)> during;
+
 	rule<Expression *(Scope &)> empty_statement;
 
 	rule<Return *(Scope &)> return_stmt;

--- a/src/semantics/readylog/action.cpp
+++ b/src/semantics/readylog/action.cpp
@@ -31,10 +31,6 @@
 namespace gologpp {
 
 
-Semantics<Action>::Semantics(const Action &a)
-: AbstractSemantics<Action>(a)
-{}
-
 
 EC_word Semantics<Action>::durative_action()
 {
@@ -99,10 +95,6 @@ EC_word Semantics<Action>::senses()
 }
 
 
-Semantics<ExogAction>::Semantics(const ExogAction &a)
-: AbstractSemantics<ExogAction>(a)
-{}
-
 
 EC_word Semantics<ExogAction>::exog_action()
 {
@@ -143,35 +135,21 @@ EC_word Semantics<ExogAction>::poss()
 
 
 
+EC_word Semantics<ExogEvent>::plterm()
+{ return reference_term(element()); }
+
+
+
 const Activity &Semantics<Activity>::activity()
 { return dynamic_cast<const Activity &>(element()); }
 
 
 EC_word Semantics<Activity>::plterm()
 {
-	string state;
-
-	switch (activity().state()) {
-	case Activity::State::IDLE:
-		state = "idle";
-		break;
-	case Activity::State::RUNNING:
-		state = "running";
-		break;
-	case Activity::State::FINAL:
-		state = "final";
-		break;
-	case Activity::State::FAILED:
-		state = "failed";
-		break;
-	case Activity::State::PREEMPTED:
-		state = "preempted";
-	}
-
 	return ::term(EC_functor("exog_state_change", 3),
-		Semantics<Grounding<Action>>::plterm(),
+		reference_term(element()),
 		EC_word(ReadylogContext::instance().backend().time().time_since_epoch().count()),
-		EC_atom(state.c_str())
+		EC_atom(to_string(element().state()).c_str())
 	);
 }
 
@@ -191,24 +169,8 @@ const Transition &Semantics<Transition>::trans()
 
 EC_word Semantics<Transition>::plterm()
 {
-	string name;
-
-	switch (trans().hook()) {
-	case Transition::Hook::START:
-		name = "start";
-		break;
-	case Transition::Hook::STOP:
-		name = "stop";
-		break;
-	case Transition::Hook::FAIL:
-		name = "fail";
-		break;
-	case Transition::Hook::FINISH:
-		name = "finish";
-	}
-
-	return ::term(EC_functor(name.c_str(), 2),
-		Semantics<Grounding<Action>>::plterm(),
+	return ::term(EC_functor(to_string(element().hook()).c_str(), 2),
+		reference_term(element()),
 		EC_word(ReadylogContext::instance().backend().time().time_since_epoch().count())
 	);
 }

--- a/src/semantics/readylog/action.h
+++ b/src/semantics/readylog/action.h
@@ -37,7 +37,7 @@ class Semantics<Action>
 , public AbstractSemantics<Action>
 {
 public:
-	Semantics(const Action &a);
+	using AbstractSemantics<Action>::AbstractSemantics;
 	virtual ~Semantics() override = default;
 
 	EC_word durative_action();
@@ -55,7 +55,7 @@ class Semantics<ExogAction>
 , public AbstractSemantics<ExogAction>
 {
 public:
-	Semantics(const ExogAction &a);
+	using AbstractSemantics<ExogAction>::AbstractSemantics;
 	virtual ~Semantics() override = default;
 
 	EC_word exog_action();
@@ -67,17 +67,25 @@ public:
 
 
 template<>
-class Semantics<ExogEvent> : public Semantics<Grounding<ExogAction>> {
+class Semantics<ExogEvent>
+: public Semantics<AbstractLanguageElement>
+, public AbstractSemantics<ExogEvent>
+{
 public:
-	using Semantics<Grounding<ExogAction>>::Semantics;
+	using AbstractSemantics<ExogEvent>::AbstractSemantics;
 	virtual ~Semantics() override = default;
+
+	virtual EC_word plterm() override;
 };
 
 
 template<>
-class Semantics<Activity> : public Semantics<Grounding<Action>> {
+class Semantics<Activity>
+: public Semantics<AbstractLanguageElement>
+, public AbstractSemantics<Activity>
+{
 public:
-	using Semantics<Grounding<Action>>::Semantics;
+	using AbstractSemantics<Activity>::AbstractSemantics;
 	virtual ~Semantics() override = default;
 
 	const Activity &activity();
@@ -88,9 +96,12 @@ public:
 
 
 template<>
-class Semantics<Transition> : public Semantics<Grounding<Action>> {
+class Semantics<Transition>
+: public Semantics<AbstractLanguageElement>
+, public AbstractSemantics<Transition>
+{
 public:
-	using Semantics<Grounding<Action>>::Semantics;
+	using AbstractSemantics<Transition>::AbstractSemantics;
 	virtual ~Semantics() override = default;
 
 	const Transition &trans();

--- a/src/semantics/readylog/boilerplate.pl
+++ b/src/semantics/readylog/boilerplate.pl
@@ -214,6 +214,44 @@ causes_val(finish(A, _T), state(A), final, true) :- durative_action(A).
 causes_val(finish(A, T), F, V, C) :- durative_causes_val(A, F, V, C).
 
 
+% end action
+% ==========
+prim_action(end(A, _T)) :- durative_action(A).
+poss(end(A, T),
+	and(
+		lif(online
+			% Online: Wait for real action to complete
+			, or( [
+				state(A) = final
+				, state(A) = failed
+				, state(A) = cancelled
+			] )
+			% Offline: Final immediately
+			, true
+		)
+		, now >= T
+	)
+) :- durative_action(A).
+
+% ONLY During planning end(A) puts A in the final state.
+% Online this happens exogenously.
+causes_val(end(A, _T), state(A), final, not(online)) :- durative_action(A).
+
+% Offline: Just apply effect & disregard state because state is changed
+%          by another effect.
+% Online:  Apply effect only if state is final
+causes_val(
+	end(A, _T)
+	, F, V
+	, lif(online
+		, and(state(A) = final, C)
+		, C
+	)
+) :-
+	durative_causes_val(A, F, V, C)
+.
+
+
 % stop action
 % ===========
 prim_action(stop(A, _T)) :- durative_action(A).

--- a/src/semantics/readylog/boilerplate.pl
+++ b/src/semantics/readylog/boilerplate.pl
@@ -226,7 +226,7 @@ poss(stop(A, T),
 		, now >= T
 	)
 ) :- durative_action(A).
-causes_val(stop(A, _T), state(A), preempted, true) :- durative_action(A).
+causes_val(stop(A, _T), state(A), cancelled, true) :- durative_action(A).
 
 
 % fail action

--- a/src/semantics/readylog/fluent.cpp
+++ b/src/semantics/readylog/fluent.cpp
@@ -86,26 +86,22 @@ EC_word Semantics<InitialValue>::plterm()
 
 
 
-Semantics<Fluent>::Semantics(const Fluent &f)
-: fluent_(f)
-{}
-
 EC_word Semantics<Fluent>::plterm()
 {
-	if (fluent_.arity() > 0)
+	if (element().arity() > 0)
 		return ::term(
-			EC_functor(fluent_.name().c_str(), fluent_.arity()),
-			to_ec_words(fluent_.params()).data()
+			EC_functor(element().name().c_str(), element().arity()),
+			to_ec_words(element().params()).data()
 		);
 	else
-		return EC_atom(fluent_.name().c_str());
+		return EC_atom(element().name().c_str());
 }
 
 
 vector<EC_word> Semantics<Fluent>::initially()
 {
 	vector<EC_word> rv;
-	for (const unique_ptr<InitialValue> &ival : fluent_.initially())
+	for (const unique_ptr<InitialValue> &ival : element().initially())
 		rv.push_back(ival->semantics().plterm());
 
 	return rv;
@@ -114,10 +110,10 @@ vector<EC_word> Semantics<Fluent>::initially()
 
 EC_word Semantics<Fluent>::prim_fluent()
 {
-	fluent_.scope().semantics().init_vars();
+	element().scope().semantics().init_vars();
 
 	vector<EC_word> arg_domains;
-	for (const shared_ptr<Variable> &arg : fluent_.params())
+	for (const shared_ptr<Variable> &arg : element().params())
 		if (arg->domain().is_defined())
 			arg_domains.emplace_back(
 				arg->semantics().member_restriction()

--- a/src/semantics/readylog/fluent.h
+++ b/src/semantics/readylog/fluent.h
@@ -42,17 +42,17 @@ public:
 
 
 template<>
-class Semantics<Fluent> : public Semantics<AbstractLanguageElement> {
+class Semantics<Fluent>
+: public Semantics<AbstractLanguageElement>
+, public AbstractSemantics<Fluent>
+{
 public:
-	Semantics(const Fluent &f);
+	using AbstractSemantics<Fluent>::AbstractSemantics;
 	virtual ~Semantics() override = default;
 
 	virtual EC_word plterm() override;
 	vector<EC_word> initially();
 	EC_word prim_fluent();
-
-private:
-	const Fluent &fluent_;
 };
 
 

--- a/src/semantics/readylog/history.cpp
+++ b/src/semantics/readylog/history.cpp
@@ -77,7 +77,7 @@ vector<unique_ptr<Value>> get_args(EC_word head) {
 
 static const std::unordered_map<string, Transition::Hook> name2state {
 	{ "start", Transition::Hook::START },
-	{ "stop", Transition::Hook::STOP },
+	{ "stop", Transition::Hook::CANCEL },
 	{ "finish", Transition::Hook::FINISH },
 	{ "fail", Transition::Hook::FAIL },
 };

--- a/src/semantics/readylog/history.cpp
+++ b/src/semantics/readylog/history.cpp
@@ -77,9 +77,10 @@ vector<unique_ptr<Value>> get_args(EC_word head) {
 
 static const std::unordered_map<string, Transition::Hook> name2state {
 	{ "start", Transition::Hook::START },
-	{ "stop", Transition::Hook::CANCEL },
+	{ "cancel", Transition::Hook::CANCEL },
 	{ "finish", Transition::Hook::FINISH },
 	{ "fail", Transition::Hook::FAIL },
+	{ "end", Transition::Hook::END }
 };
 
 

--- a/src/semantics/readylog/procedural.cpp
+++ b/src/semantics/readylog/procedural.cpp
@@ -20,16 +20,12 @@
 #include "reference.h"
 #include "execution.h"
 #include "value.h"
+#include "action.h"
 
 #include <model/procedural.h>
 
 
 namespace gologpp {
-
-
-Semantics<Function>::Semantics(const Function &function)
-: AbstractSemantics<Function>(function)
-{}
 
 
 EC_word Semantics<Function>::plterm()
@@ -76,11 +72,6 @@ EC_word Semantics<Function>::return_var()
 
 
 
-Semantics<Block>::Semantics(const Block &b)
-: AbstractSemantics<Block>(b)
-{}
-
-
 EC_word Semantics<Block>::plterm()
 {
 	element().scope().semantics().init_vars();
@@ -111,21 +102,12 @@ void Semantics<Block>::set_current_program(EC_word e)
 
 
 
-Semantics<Choose>::Semantics(const Choose &c)
-: AbstractSemantics<Choose>(c)
-{}
-
 EC_word Semantics<Choose>::plterm()
 {
 	element().scope().semantics().init_vars();
 	return ::term(EC_functor("nondet", 1), to_ec_list(element().alternatives()));
 }
 
-
-
-Semantics<Conditional>::Semantics(const Conditional &c)
-: AbstractSemantics<Conditional>(c)
-{}
 
 
 EC_word Semantics<Conditional>::plterm()
@@ -150,11 +132,6 @@ EC_word Semantics<Conditional>::plterm()
 
 
 
-Semantics<Concurrent>::Semantics(const Concurrent &c)
-: AbstractSemantics<Concurrent>(c)
-{}
-
-
 EC_word Semantics<Concurrent>::plterm()
 {
 	element().scope().semantics().init_vars();
@@ -162,9 +139,6 @@ EC_word Semantics<Concurrent>::plterm()
 }
 
 
-Semantics<Assignment<Reference<Fluent>>>::Semantics(const Assignment<Reference<Fluent>> &ass)
-: AbstractSemantics<Assignment<Reference<Fluent>>>(ass)
-{}
 
 EC_word Semantics<Assignment<Reference<Fluent>>>::plterm()
 {
@@ -210,11 +184,6 @@ std::pair<const Reference<Fluent> *, EC_word> traverse_mixed_field_access(const 
 };
 
 
-Semantics<Assignment<FieldAccess>>::Semantics(const Assignment<FieldAccess> &ass)
-: AbstractSemantics<Assignment<FieldAccess>>(ass)
-, field_access_(ass.lhs())
-{}
-
 
 EC_word Semantics<Assignment<FieldAccess>>::plterm()
 {
@@ -231,12 +200,6 @@ EC_word Semantics<Assignment<FieldAccess>>::plterm()
 	);
 }
 
-
-
-Semantics<Assignment<ListAccess>>::Semantics(const Assignment<ListAccess> &ass)
-: AbstractSemantics<Assignment<ListAccess> >(ass)
-, field_access_(ass.lhs())
-{}
 
 
 EC_word Semantics<Assignment<ListAccess>>::plterm()
@@ -276,11 +239,6 @@ EC_word Semantics<Pick>::plterm()
 
 
 
-Semantics<Search>::Semantics(const Search &search)
-: AbstractSemantics<Search>(search)
-{}
-
-
 EC_word Semantics<Search>::plterm()
 {
 	return ::term(EC_functor("search", 1),
@@ -288,11 +246,6 @@ EC_word Semantics<Search>::plterm()
 	);
 }
 
-
-
-Semantics<Solve>::Semantics(const Solve &solve)
-: AbstractSemantics<Solve>(solve)
-{}
 
 
 EC_word Semantics<Solve>::plterm()
@@ -306,11 +259,6 @@ EC_word Semantics<Solve>::plterm()
 
 
 
-Semantics<Test>::Semantics(const Test &test)
-: AbstractSemantics<Test>(test)
-{}
-
-
 EC_word Semantics<Test>::plterm()
 {
 	return ::term(EC_functor("?", 1),
@@ -318,11 +266,6 @@ EC_word Semantics<Test>::plterm()
 	);
 }
 
-
-
-Semantics<While>::Semantics(const While &w)
-: AbstractSemantics<While>(w)
-{}
 
 
 EC_word Semantics<While>::plterm()
@@ -334,10 +277,6 @@ EC_word Semantics<While>::plterm()
 }
 
 
-
-Semantics<Return>::Semantics(const Return &r)
-: AbstractSemantics<Return>(r)
-{}
 
 EC_word Semantics<Return>::plterm() {
 	const AbstractLanguageElement *root_parent = element().parent();
@@ -364,11 +303,6 @@ EC_word Semantics<Return>::plterm() {
 
 
 
-Semantics<DurativeCall>::Semantics(const DurativeCall &call)
-: AbstractSemantics<DurativeCall>(call)
-{}
-
-
 EC_word Semantics<DurativeCall>::plterm()
 {
 	return ::term(EC_functor(to_string(element().hook()).c_str(), 2),
@@ -378,11 +312,6 @@ EC_word Semantics<DurativeCall>::plterm()
 }
 
 
-
-Semantics<FieldAccess>::Semantics(const FieldAccess &field_access)
-: AbstractSemantics<FieldAccess>(field_access)
-, is_lvalue_(false)
-{}
 
 EC_word Semantics<FieldAccess>::plterm()
 {
@@ -406,14 +335,7 @@ EC_word Semantics<FieldAccess>::field_assign(const Expression &value)
 	);
 }
 
-void Semantics<FieldAccess>::set_lvalue(bool lvalue)
-{ is_lvalue_ = lvalue; }
 
-
-
-Semantics<ListAccess>::Semantics(const ListAccess &list_access)
-: AbstractSemantics<ListAccess>(list_access)
-{}
 
 EC_word Semantics<ListAccess>::pl_index()
 { return element().index().semantics().plterm(); }
@@ -428,10 +350,6 @@ EC_word Semantics<ListAccess>::plterm()
 }
 
 
-
-Semantics<ListPop>::Semantics(const ListPop &list_pop)
-: AbstractSemantics<ListPop>(list_pop)
-{}
 
 EC_word Semantics<ListPop>::plterm()
 {
@@ -458,10 +376,6 @@ EC_word Semantics<ListPop>::plterm()
 
 
 
-Semantics<ListPush>::Semantics(const ListPush &list_push)
-: AbstractSemantics<ListPush>(list_push)
-{}
-
 EC_word Semantics<ListPush>::plterm()
 {
 	string fn;
@@ -486,10 +400,6 @@ EC_word Semantics<ListPush>::plterm()
 }
 
 
-
-Semantics<ListLength>::Semantics(const ListLength &list_length)
-: AbstractSemantics<ListLength>(list_length)
-{}
 
 EC_word Semantics<ListLength>::plterm()
 {

--- a/src/semantics/readylog/procedural.cpp
+++ b/src/semantics/readylog/procedural.cpp
@@ -410,4 +410,40 @@ EC_word Semantics<ListLength>::plterm()
 
 
 
+EC_word Semantics<During>::plterm()
+{
+	EC_word start = ::term(EC_functor(to_string(Transition::Hook::START).c_str(), 2),
+		reference_term(element().action_call()),
+		EC_atom("now")
+	);
+	EC_word end = ::term(EC_functor(to_string(Transition::Hook::END).c_str(), 2),
+		reference_term(element().action_call()),
+		EC_atom("now")
+	);
+	EC_word if_failed = ::term(EC_functor("if", 2),
+		::term(EC_functor("=", 2),
+			::term(EC_functor("state", 1), reference_term(element().action_call())),
+			::EC_atom(to_string(Activity::State::FAILED).c_str())
+		),
+		element().on_fail().semantics().plterm()
+	);
+	EC_word if_cancelled = ::term(EC_functor("if", 2),
+		::term(EC_functor("=", 2),
+			::term(EC_functor("state", 1), reference_term(element().action_call())),
+			::EC_atom(to_string(Activity::State::CANCELLED).c_str())
+		),
+		element().on_cancel().semantics().plterm()
+	);
+
+	return make_ec_list( {
+		start,
+		element().parallel_block().semantics().plterm(),
+		end,
+		if_failed,
+		if_cancelled
+	} );
+}
+
+
+
 }

--- a/src/semantics/readylog/procedural.h
+++ b/src/semantics/readylog/procedural.h
@@ -46,7 +46,7 @@ class Semantics<Function>
 , public AbstractSemantics<Function>
 {
 public:
-	Semantics(const Function &function);
+	using AbstractSemantics<Function>::AbstractSemantics;
 	virtual EC_word plterm() override;
 	virtual EC_word definition();
 	EC_word return_var();
@@ -63,7 +63,7 @@ class Semantics<Block>
 , public AbstractSemantics<Block>
 {
 public:
-	Semantics(const Block &);
+	using AbstractSemantics<Block>::AbstractSemantics;
 	virtual EC_word plterm() override;
 	EC_word current_program();
 	void set_current_program(EC_word e);
@@ -80,7 +80,7 @@ class Semantics<Choose>
 , public AbstractSemantics<Choose>
 {
 public:
-	Semantics(const Choose &);
+	using AbstractSemantics<Choose>::AbstractSemantics;
 	virtual EC_word plterm() override;
 };
 
@@ -92,7 +92,7 @@ class Semantics<Conditional>
 , public AbstractSemantics<Conditional>
 {
 public:
-	Semantics(const Conditional &);
+	using AbstractSemantics<Conditional>::AbstractSemantics;
 	virtual EC_word plterm() override;
 };
 
@@ -104,7 +104,7 @@ class Semantics<Concurrent>
 , public AbstractSemantics<Concurrent>
 {
 public:
-	Semantics(const Concurrent &);
+	using AbstractSemantics<Concurrent>::AbstractSemantics;
 	virtual EC_word plterm() override;
 };
 
@@ -134,8 +134,7 @@ class Semantics<Assignment<Reference<Fluent>>>
 , public AbstractSemantics<Assignment<Reference<Fluent>>>
 {
 public:
-	Semantics(const Assignment<Reference<Fluent>> &ass);
-
+	using AbstractSemantics<Assignment<Reference<Fluent>>>::AbstractSemantics;
 	virtual EC_word plterm() override;
 };
 
@@ -147,12 +146,8 @@ class Semantics<Assignment<FieldAccess>>
 , public AbstractSemantics<Assignment<FieldAccess>>
 {
 public:
-	Semantics(const Assignment<FieldAccess> &ass);
-
+	using AbstractSemantics<Assignment<FieldAccess>>::AbstractSemantics;
 	virtual EC_word plterm() override;
-
-private:
-	const FieldAccess &field_access_;
 };
 
 
@@ -163,12 +158,8 @@ class Semantics<Assignment<ListAccess>>
 , public AbstractSemantics<Assignment<ListAccess>>
 {
 public:
-	Semantics(const Assignment<ListAccess> &ass);
-
+	using AbstractSemantics<Assignment<ListAccess>>::AbstractSemantics;
 	virtual EC_word plterm() override;
-
-private:
-	const ListAccess &field_access_;
 };
 
 
@@ -179,7 +170,7 @@ class Semantics<Pick>
 , public AbstractSemantics<Pick>
 {
 public:
-	Semantics(const Pick &pick);
+	Semantics(const Pick &);
 	virtual EC_word plterm() override;
 };
 
@@ -191,7 +182,7 @@ class Semantics<Search>
 , public AbstractSemantics<Search>
 {
 public:
-	Semantics(const Search &);
+	using AbstractSemantics<Search>::AbstractSemantics;
 	virtual EC_word plterm() override;
 };
 
@@ -203,7 +194,7 @@ class Semantics<Solve>
 , public AbstractSemantics<Solve>
 {
 public:
-	Semantics(const Solve &);
+	using AbstractSemantics<Solve>::AbstractSemantics;
 	virtual EC_word plterm() override;
 };
 
@@ -215,7 +206,7 @@ class Semantics<Test>
 , public AbstractSemantics<Test>
 {
 public:
-	Semantics(const Test &);
+	using AbstractSemantics<Test>::AbstractSemantics;
 	virtual EC_word plterm() override;
 };
 
@@ -227,7 +218,7 @@ class Semantics<While>
 , public AbstractSemantics<While>
 {
 public:
-	Semantics(const While &);
+	using AbstractSemantics<While>::AbstractSemantics;
 	virtual EC_word plterm() override;
 };
 
@@ -239,7 +230,7 @@ class Semantics<Return>
 , public AbstractSemantics<Return>
 {
 public:
-	Semantics(const Return &r);
+	using AbstractSemantics<Return>::AbstractSemantics;
 	virtual EC_word plterm() override;
 };
 
@@ -251,7 +242,7 @@ class Semantics<DurativeCall>
 , public AbstractSemantics<DurativeCall>
 {
 public:
-	Semantics(const DurativeCall &call);
+	using AbstractSemantics<DurativeCall>::AbstractSemantics;
 	virtual EC_word plterm() override;
 };
 
@@ -266,15 +257,11 @@ class Semantics<FieldAccess>
 , public AbstractSemantics<FieldAccess>
 {
 public:
-	Semantics(const FieldAccess &field_access);
+	using AbstractSemantics<FieldAccess>::AbstractSemantics;
 
 	virtual EC_word plterm() override;
 	EC_word field_assign(const Expression &value);
 	EC_atom pl_field_name();
-	void set_lvalue(bool lvalue);
-
-private:
-	bool is_lvalue_;
 };
 
 
@@ -285,7 +272,7 @@ class Semantics<ListAccess>
 , public AbstractSemantics<ListAccess>
 {
 public:
-	Semantics(const ListAccess &list_access);
+	using AbstractSemantics<ListAccess>::AbstractSemantics;
 
 	virtual EC_word plterm() override;
 	EC_word pl_index();
@@ -299,8 +286,7 @@ class Semantics<ListPop>
 , public AbstractSemantics<ListPop>
 {
 public:
-	Semantics(const ListPop &list_access);
-
+	using AbstractSemantics<ListPop>::AbstractSemantics;
 	virtual EC_word plterm() override;
 };
 
@@ -312,8 +298,7 @@ class Semantics<ListPush>
 , public AbstractSemantics<ListPush>
 {
 public:
-	Semantics(const ListPush &list_access);
-
+	using AbstractSemantics<ListPush>::AbstractSemantics;
 	virtual EC_word plterm() override;
 };
 

--- a/src/semantics/readylog/procedural.h
+++ b/src/semantics/readylog/procedural.h
@@ -310,11 +310,21 @@ class Semantics<ListLength>
 , public AbstractSemantics<ListLength>
 {
 public:
-	Semantics(const ListLength &list_access);
-
+	using AbstractSemantics<ListLength>::AbstractSemantics;
 	virtual EC_word plterm() override;
 };
 
+
+
+template<>
+class Semantics<During>
+: public Semantics<AbstractLanguageElement>
+, public AbstractSemantics<During>
+{
+public:
+	using AbstractSemantics<During>::AbstractSemantics;
+	virtual EC_word plterm() override;
+};
 
 
 } // namespace gologpp

--- a/src/semantics/readylog/reference.cpp
+++ b/src/semantics/readylog/reference.cpp
@@ -34,7 +34,7 @@ template<>
 EC_word Semantics<Reference<Action>>::plterm()
 {
 	return ::list(::term(EC_functor("start", 2), reference_term(element()), EC_atom("now")),
-		::list(::term(EC_functor("finish", 2), reference_term(element()), EC_atom("now")),
+		::list(::term(EC_functor("end", 2), reference_term(element()), EC_atom("now")),
 			::nil()
 		)
 	);

--- a/src/semantics/readylog/reference.h
+++ b/src/semantics/readylog/reference.h
@@ -63,40 +63,25 @@ EC_word reference_term(const ReferenceBase<GologT, ExprT> &ref)
 
 
 
-template<class GologT, class ExprT>
-class Semantics<ReferenceBase<GologT, ExprT>>
+template<class TargetT>
+class Semantics<Reference<TargetT>>
 : public Semantics<Expression>
-, public AbstractSemantics<ReferenceBase<GologT, ExprT>>
+, public AbstractSemantics<Reference<TargetT>>
 {
 public:
-	Semantics(const ReferenceBase<GologT, ExprT> &ref)
-	: AbstractSemantics<ReferenceBase<GologT, ExprT>>(ref)
-	{}
+	using AbstractSemantics<Reference<TargetT>>::AbstractSemantics;
 
 	virtual EC_word plterm() override
-	{ return reference_term(element<ReferenceBase<GologT, ExprT>>()); }
+	{
+		return reference_term(
+			AbstractSemantics<Reference<TargetT>>::template element()
+		);
+	}
 };
-
 
 
 template<>
-EC_word Semantics<ReferenceBase<Action, Expression>>::plterm();
-
-
-
-template<class TargetT>
-class Semantics<Grounding<TargetT>> : public Semantics<ReferenceBase<TargetT, Value>> {
-public:
-	using Semantics<ReferenceBase<TargetT, Value>>::Semantics;
-};
-
-
-
-template<class TargetT>
-class Semantics<Reference<TargetT>> : public Semantics<ReferenceBase<TargetT, Expression>> {
-public:
-	using Semantics<ReferenceBase<TargetT, Expression>>::Semantics;
-};
+EC_word Semantics<Reference<Action>>::plterm();
 
 
 

--- a/src/semantics/readylog/utilities.cpp
+++ b/src/semantics/readylog/utilities.cpp
@@ -54,6 +54,22 @@ EC_word to_ec_list(const vector<EC_word> &vec, typename vector<EC_word>::const_i
 
 
 
+EC_word make_ec_list(
+	const std::vector<EC_word> &words,
+	std::vector<EC_word>::const_iterator pos
+) {
+	if (pos == words.end())
+		return ::nil();
+	else
+		return ::list(*pos, make_ec_list(words, pos + 1));
+}
+
+
+EC_word make_ec_list(const std::vector<EC_word> &words)
+{ return make_ec_list(words, words.begin()); }
+
+
+
 EC_word copy_term(EC_word t)
 {
 	EC_functor fn;

--- a/src/semantics/readylog/utilities.h
+++ b/src/semantics/readylog/utilities.h
@@ -107,6 +107,9 @@ EC_word to_ec_list(const ListT &vec)
 { return to_ec_list(vec, vec.cbegin()); }
 
 
+EC_word make_ec_list(const std::vector<EC_word> &words);
+
+
 EC_word copy_term(EC_word t);
 
 


### PR DESCRIPTION
This is a first shot at a syntactially integrated way to handle action failures. With the during construct, we can specify what should happen while an action is being executed, and what should be done on failure and on cancel. The construct terminates after both the action itself and the code running in parallel have terminated.

Furthermore, this PR introduces a primitive action `end(A)`, which is executable when the durative action `A` is either `final`, `failed` or `cancelled`. The default semantics of trivial action calls is changed to not end the action with `final(A)`, but with `end(A)`. So the program won't just block any more when an action fails.