### PR TITLE
implement progression

### DIFF
--- a/src/model/execution.cpp
+++ b/src/model/execution.cpp
@@ -111,6 +111,7 @@ ExecutionContext::~ExecutionContext()
 Clock::time_point ExecutionContext::context_time() const
 { return context_time_; }
 
+
 void ExecutionContext::run(Block &&program)
 {
 	history().attach_semantics(semantics_factory());
@@ -150,6 +151,11 @@ void ExecutionContext::run(Block &&program)
 				exog->attach_semantics(semantics_factory());
 				history().abstract_semantics().append_exog(exog);
 			}
+		}
+
+		if (history().abstract_semantics().should_progress()) {
+			std::cout << "=== Progressing history." << std::endl;
+			history().abstract_semantics().progress();
 		}
 	}
 

--- a/src/model/history.h
+++ b/src/model/history.h
@@ -35,6 +35,8 @@ public:
 	virtual shared_ptr<Transition> get_last_transition() = 0;
 	virtual void append_exog(shared_ptr<Grounding<AbstractAction>>) = 0;
 	virtual void append_sensing_result(shared_ptr<Activity>) = 0;
+	virtual bool should_progress() const = 0;
+	virtual void progress() = 0;
 
 	const History &element() const;
 

--- a/src/semantics/readylog/boilerplate.pl
+++ b/src/semantics/readylog/boilerplate.pl
@@ -6,6 +6,11 @@
 % resolve name clash with lib(listut)
 :- import delete/3 from eclipse_language.
 
+should_progress(H) :- length(H, L), L >= 10.
+
+% execute/3 is useless in golog++. Just ignore it and log a message
+execute(Action, _Sr, _H) :- printf("Dummy execute %W%n", [Action]).
+
 function(strcat(X, Y), R, concat_atoms(X, Y, R)).
 function(to_string(V), R,
 	and(sprintf(S, "%w", V), atom_string(R, S))

--- a/src/semantics/readylog/execution.cpp
+++ b/src/semantics/readylog/execution.cpp
@@ -280,7 +280,7 @@ bool ReadylogContext::trans(Block &program, History &history)
 		else {
 			// Successful transition
 			program.semantics().set_current_program(e1);
-			history.semantics().set_current_history(h1);
+			history.semantics().extend_history(h1);
 			return true;
 		}
 	} else

--- a/src/semantics/readylog/history.h
+++ b/src/semantics/readylog/history.h
@@ -35,8 +35,11 @@ public:
 	virtual shared_ptr<Transition> get_last_transition() override;
 	virtual void append_exog(shared_ptr<Grounding<AbstractAction>> exog) override;
 	virtual void append_sensing_result(shared_ptr<Activity>) override;
-	EC_word current_history();
-	void set_current_history(EC_word h);
+	virtual bool should_progress() const override;
+	virtual void progress() override;
+
+	EC_word current_history() const;
+	void extend_history(EC_word h);
 	bool has_changed() const;
 
 private:


### PR DESCRIPTION
This PR enables progression. Note that it requires some patches to the ReadyLog interpreter as well. In particular, for some reason ReadyLog used to restrict all fluent parameters to the integers domain (specifically during progression), which of course breaks pretty much all of our use cases.