### PR TITLE
type system overhaul

### DIFF
--- a/examples/blocksworld.gpp
+++ b/examples/blocksworld.gpp
@@ -15,12 +15,10 @@
  * along with golog++.  If not, see <https://www.gnu.org/licenses/>.
 **************************************************************************/
 
-symbol domain blocks = {a, b, c}
-symbol domain locations = blocks | {table}
+symbol domain block = {a, b, c}
+symbol domain location = block | {table}
 
-symbol fluent loc(symbol x) {
-domain:
-	x in blocks;
+location fluent loc(block x) {
 initially:
 	(a) = c;
 	(b) = table;
@@ -28,18 +26,15 @@ initially:
 // 	(d) = a; //*/
 }
 
-action stack(symbol x, symbol y) {
-domain:
-	x in blocks;
-	y in locations;
+action stack(block x, location y) {
 precondition:
 	  x != y // Can't stack x on x
 	& x != table // Can't stack table
 	& loc(x) != y // Can't stack the same thing twice
-	& (!exists(symbol z) loc(z) == x) // Nothing is on x
+	& (!exists(block z) loc(z) == x) // Nothing is on x
 	& (
 		y == table // either y is the table...
-		| !exists(symbol z) loc(z) == y // or nothing is on y
+		| !exists(block z) loc(z) == y // or nothing is on y
 	)
 
 effect:
@@ -67,7 +62,7 @@ number function reward() =
 {
 	solve(8, reward())
 		while (!goal())
-			pick (symbol x in {a, b, c})
-				pick(symbol y in {table, a, b, c})
+			pick (block x in {a, b, c})
+				pick(location y in {table, a, b, c})
 					stack(x, y);
 }

--- a/examples/blocksworld.gpp
+++ b/examples/blocksworld.gpp
@@ -53,18 +53,15 @@ procedure bla() {
 }
 
 
-bool function goal() {
-	return loc(a) == table & loc(b) == a & loc(c) == b
-// 	& loc(d) == c
-	;
-}
+bool function goal() =
+	loc(a) == table & loc(b) == a & loc(c) == b
 
-number function reward() {
+
+number function reward() =
 	if (goal())
-		return 100;
+		100
 	else
-		return -1;
-}
+		-1
 
 
 {

--- a/src/model/action.cpp
+++ b/src/model/action.cpp
@@ -30,7 +30,7 @@ AbstractAction::AbstractAction(
 	const string &name,
 	const vector<shared_ptr<Variable>> &params
 )
-: Global(name, params)
+: Signified<Instruction>(name, params)
 , ScopeOwner(own_scope)
 {
 	set_type_by_name(VoidType::name());
@@ -128,7 +128,7 @@ string Action::to_string(const string &pfx) const
 Reference<Action> *Action::make_ref(const vector<Expression *> &args)
 { return make_ref_<Action>(args); }
 
-Expression *Action::ref(const vector<Expression *> &args)
+Instruction *Action::ref(const vector<Expression *> &args)
 { return make_ref(args); }
 
 void Action::set_senses(Reference<Fluent> *f)
@@ -174,7 +174,7 @@ string ExogAction::to_string(const string &pfx) const
 Reference<ExogAction> *ExogAction::make_ref(const vector<Expression *> &args)
 { return make_ref_<ExogAction>(args); }
 
-Expression *ExogAction::ref(const vector<Expression *> &args)
+Instruction *ExogAction::ref(const vector<Expression *> &args)
 { return make_ref(args); }
 
 

--- a/src/model/action.cpp
+++ b/src/model/action.cpp
@@ -26,15 +26,15 @@ namespace gologpp {
 
 AbstractAction::AbstractAction(
 	Scope *own_scope,
-	const string &, // ignored type_name
+	const Type &, // ignored type
 	const string &name,
 	const vector<shared_ptr<Variable>> &params
 )
 : Signified<Instruction>(name, params)
 , ScopeOwner(own_scope)
 {
-	set_type_by_name(VoidType::name());
-	set_precondition(new Value(BoolType::name(), true));
+	set_type(gologpp::type<VoidType>());
+	set_precondition(new Value(gologpp::type<BoolType>(), true));
 
 	vector<fusion_wtf_vector<string, Expression *>> default_mapping;
 	for (const shared_ptr<Variable> &param : params)

--- a/src/model/action.h
+++ b/src/model/action.h
@@ -48,7 +48,7 @@ public:
 
 	AbstractAction(
 		Scope *own_scope,
-		const string &,
+		const Type &,
 		const string &name,
 		const vector<shared_ptr<Variable>> &params
 	);

--- a/src/model/action.h
+++ b/src/model/action.h
@@ -31,6 +31,7 @@
 #include "global.h"
 #include "mapping.h"
 #include "reference.h"
+#include "fluent.h"
 
 namespace gologpp {
 
@@ -39,7 +40,7 @@ class AbstractEffectAxiom;
 
 
 class AbstractAction
-: public Global
+: public Signified<Instruction>
 , public ScopeOwner
 , public virtual AbstractLanguageElement {
 public:
@@ -98,7 +99,7 @@ public:
 
 	virtual void attach_semantics(SemanticsFactory &) override;
 	virtual string to_string(const string &pfx) const override;
-	virtual Expression *ref(const vector<Expression *> &params) override;
+	virtual Instruction *ref(const vector<Expression *> &params) override;
 	Reference<Action> *make_ref(const vector<Expression *> &params);
 
 	unique_ptr<Reference<Fluent>> &senses();
@@ -122,7 +123,7 @@ public:
 
 	virtual void attach_semantics(SemanticsFactory &) override;
 	virtual string to_string(const string &pfx) const override;
-	virtual Expression *ref(const vector<Expression *> &params) override;
+	virtual Instruction *ref(const vector<Expression *> &params) override;
 	Reference<ExogAction> *make_ref(const vector<Expression *> &params);
 	virtual void set_mapping (ActionMapping *) override;
 };

--- a/src/model/compound_expression.cpp
+++ b/src/model/compound_expression.cpp
@@ -22,15 +22,15 @@ namespace gologpp {
 
 
 CompoundExpression::CompoundExpression(
-	const string &type_name,
+	const Type &t,
 	const vector<fusion_wtf_vector<string, Expression *> > &entries
 )
 {
-	set_type_unchecked(type_name);
+	set_type(t);
 
 	if (!AbstractLanguageElement::type().is_compound())
 		throw TypeError("Attempt to construct CompoundExpression, but type name \""
-			+ type_name + "\" does not refer to a compound type");
+			+ type().name() + "\" does not refer to a compound type");
 
 	std::unordered_set<string> unassigned_fields = type().field_names();
 
@@ -38,7 +38,7 @@ CompoundExpression::CompoundExpression(
 		const string &field_name = boost::fusion::at_c<0>(entry);
 		const Type &field_type = type().field_type(field_name);
 		Expression *expr = boost::fusion::at_c<1>(entry);
-		if (field_type == expr->type())
+		if (field_type >= expr->type())
 			entries_.emplace(field_name, expr);
 		else
 			throw ExpressionTypeMismatch("Cannot assign " + expr->str()

--- a/src/model/compound_expression.h
+++ b/src/model/compound_expression.h
@@ -35,7 +35,7 @@ class CompoundExpression
 , public NoScopeOwner
 {
 public:
-	CompoundExpression(const string &type_name, const vector<fusion_wtf_vector<string, Expression *>> &entries);
+	CompoundExpression(const Type &type, const vector<fusion_wtf_vector<string, Expression *>> &entries);
 
 	const Expression &entry(const string &key) const;
 

--- a/src/model/domain.h
+++ b/src/model/domain.h
@@ -36,20 +36,20 @@ namespace gologpp {
  * We also don't need explicit reference representation, i.e. there is no Reference<Domain<...>>.
  * Since domains don't have arguments and anonymous domains can always appear inline,
  * the syntactic separation between named global definition and inline specification is not needed.
+ * A Domain's type is always the @a VoidType since it doesn't represent a value by itself.
  */
 class Domain
 : public virtual AbstractLanguageElement
-, public Name
+, public Type
 , public NoScopeOwner
 , public LanguageElement<Domain>
-, public std::enable_shared_from_this<Domain>
 {
 public:
 	typedef std::unordered_set<unique_ptr<Value>> ElementSet;
 	typedef typename ElementSet::iterator ElementIterator;
 
-	Domain(const string &name, const string &type_name, const vector<Value *> &elements = {}, bool implicit = false);
-	Domain(const string &type_name);
+	Domain(const string &name, const Type &elem_type, const vector<Value *> &elements = {}, bool implicit = false);
+	Domain(const Type &elem_type);
 	Domain(const string &name, const Domain &other);
 	Domain(const Domain &other);
 	Domain();
@@ -57,6 +57,10 @@ public:
 	virtual ~Domain() override = default;
 
 	Domain &operator = (const Domain &other);
+
+	virtual bool operator <= (const Type &other) const override;
+	virtual bool operator >= (const Type &other) const override;
+	virtual bool operator >= (const AbstractLanguageElement &e) const override;
 
 
 	/**
@@ -72,6 +76,8 @@ public:
 
 	ElementSet &elements();
 	const ElementSet &elements() const;
+
+	const Type &element_type() const;
 
 	void add_element(const Value &c);
 
@@ -92,11 +98,14 @@ public:
 
 	virtual string to_string(const string &) const override;
 
-
 private:
+	static string next_anon_name();
+
 	ElementSet elements_;
+	shared_ptr<const Type> element_type_;
 	std::unordered_set<AbstractLanguageElement *> subjects_;
 	bool implicit_;
+	static size_t id_count_;
 };
 
 

--- a/src/model/effect_axiom.cpp
+++ b/src/model/effect_axiom.cpp
@@ -21,7 +21,7 @@
 namespace gologpp {
 
 AbstractEffectAxiom::AbstractEffectAxiom()
-: condition_(new Value(BoolType::name(), true))
+: condition_(new Value(gologpp::type<BoolType>(), true))
 {}
 
 AbstractEffectAxiom::~AbstractEffectAxiom()

--- a/src/model/effect_axiom.h
+++ b/src/model/effect_axiom.h
@@ -80,7 +80,8 @@ public:
 
 	void define(boost::optional<Expression *> condition, LhsT *lhs, Expression *value)
 	{
-		ensure_type_equality(*lhs, *value);
+		if (!(lhs->type() >= *value))
+			throw TypeError(*value, lhs->type());
 
 		if (condition)
 			set_condition(*condition);

--- a/src/model/error.cpp
+++ b/src/model/error.cpp
@@ -66,7 +66,7 @@ ExpressionTypeMismatch::ExpressionTypeMismatch(const string &msg)
 
 
 TypeError::TypeError(const AbstractLanguageElement &expr, const Type &t)
-: UserError("Expression `" + expr.str() + "` is not of type " + t.name())
+: UserError("Expression " + expr.str() + " is not of type " + t.name())
 {}
 
 

--- a/src/model/execution.h
+++ b/src/model/execution.h
@@ -55,6 +55,7 @@ public:
 	virtual void compile(const Fluent &fluent) = 0;
 	virtual void compile(const AbstractAction &action) = 0;
 	virtual void compile(const Function &function) = 0;
+	virtual void compile(const Procedure &function) = 0;
 	virtual void postcompile() = 0;
 
 	virtual void run(Block &&program) = 0;

--- a/src/model/expressions.cpp
+++ b/src/model/expressions.cpp
@@ -45,4 +45,28 @@ const string &Expression::type_name() const
 
 
 
+Instruction::Instruction()
+: parent_(nullptr)
+{}
+
+Scope &Instruction::parent_scope()
+{ return parent_->scope(); }
+
+const Scope &Instruction::parent_scope() const
+{ return parent_->scope(); }
+
+AbstractLanguageElement *Instruction::parent()
+{ return parent_; }
+
+const AbstractLanguageElement *Instruction::parent() const
+{ return parent_; }
+
+void Instruction::set_parent(AbstractLanguageElement *parent)
+{ parent_ = parent; }
+
+const string &Instruction::type_name() const
+{ return type().name(); }
+
+
+
 }

--- a/src/model/expressions.cpp
+++ b/src/model/expressions.cpp
@@ -40,9 +40,8 @@ const AbstractLanguageElement *Expression::parent() const
 void Expression::set_parent(AbstractLanguageElement *parent)
 { parent_ = parent; }
 
-const string &Expression::type_name() const
-{ return type().name(); }
-
+bool Expression::operator <= (const Type &t) const
+{ return t >= *this; }
 
 
 Instruction::Instruction()
@@ -63,9 +62,6 @@ const AbstractLanguageElement *Instruction::parent() const
 
 void Instruction::set_parent(AbstractLanguageElement *parent)
 { parent_ = parent; }
-
-const string &Instruction::type_name() const
-{ return type().name(); }
 
 
 

--- a/src/model/expressions.h
+++ b/src/model/expressions.h
@@ -45,8 +45,7 @@ public:
 	AbstractLanguageElement *parent();
 	const AbstractLanguageElement *parent() const;
 	void set_parent(AbstractLanguageElement *parent);
-
-	const string &type_name() const;
+	virtual bool operator <= (const Type &type) const;
 
 protected:
 	AbstractLanguageElement *parent_;
@@ -69,8 +68,6 @@ public:
 	AbstractLanguageElement *parent();
 	const AbstractLanguageElement *parent() const;
 	void set_parent(AbstractLanguageElement *parent);
-
-	const string &type_name() const;
 
 protected:
 	AbstractLanguageElement *parent_;

--- a/src/model/expressions.h
+++ b/src/model/expressions.h
@@ -54,6 +54,30 @@ protected:
 
 
 
+class Instruction : public virtual AbstractLanguageElement {
+protected:
+	Instruction();
+	Instruction(const Instruction &) = delete;
+	Instruction(Instruction &&) = default;
+	Instruction &operator = (const Instruction &) = delete;
+
+public:
+	virtual ~Instruction() override = default;
+
+	virtual Scope &parent_scope() override;
+	virtual const Scope &parent_scope() const override;
+	AbstractLanguageElement *parent();
+	const AbstractLanguageElement *parent() const;
+	void set_parent(AbstractLanguageElement *parent);
+
+	const string &type_name() const;
+
+protected:
+	AbstractLanguageElement *parent_;
+};
+
+
+
 template<class T>
 class SafeExprOwner : public std::unique_ptr<Expression> {
 public:
@@ -74,6 +98,10 @@ public:
 		return *this;
 	}
 };
+
+
+template<class T>
+using SafeVector = vector<SafeExprOwner<T>>;
 
 
 template<class T>

--- a/src/model/fluent.cpp
+++ b/src/model/fluent.cpp
@@ -93,7 +93,7 @@ const Scope &InitialValue::parent_scope() const
 
 
 Fluent::Fluent(Scope *own_scope, const string &type_name, const string &name, const vector<shared_ptr<Variable>> &args)
-: Global(name, args)
+: Signified<Expression>(name, args)
 , ScopeOwner(own_scope)
 { set_type_by_name(type_name); }
 

--- a/src/model/fluent.cpp
+++ b/src/model/fluent.cpp
@@ -92,10 +92,10 @@ const Scope &InitialValue::parent_scope() const
 
 
 
-Fluent::Fluent(Scope *own_scope, const string &type_name, const string &name, const vector<shared_ptr<Variable>> &args)
+Fluent::Fluent(Scope *own_scope, const Type &t, const string &name, const vector<shared_ptr<Variable>> &args)
 : Signified<Expression>(name, args)
 , ScopeOwner(own_scope)
-{ set_type_by_name(type_name); }
+{ set_type(t); }
 
 /*Fluent::Fluent(Scope &parent_scope, const string &name)
 : Global(name, {})
@@ -130,7 +130,9 @@ void Fluent::define(const boost::optional<vector<InitialValue *>> &initial_value
 	if (initial_values) {
 		// TODO: fail if already defined
 		for (InitialValue *ival : initial_values.get()) {
-			ensure_type_equality(*this, *ival);
+			if (!(this->type() >= ival->value()))
+				throw TypeError(ival->value(), this->type());
+
 			if (arity() != ival->args().size())
 				throw UserError("Fluent " + str() + ": Arity mismatch with initial value " + ival->str());
 
@@ -138,7 +140,8 @@ void Fluent::define(const boost::optional<vector<InitialValue *>> &initial_value
 				Variable &param = *params()[param_idx];
 				Expression &arg = *ival->args()[param_idx];
 
-				ensure_type_equality(param, arg);
+				if (!(param.type() >= arg))
+					throw TypeError(arg, param.type());
 
 				// Make sure the argument is either a value or a reference to one of this fluent's parameters
 				Reference<Variable> *var_ref = dynamic_cast<Reference<Variable> *>(&arg);

--- a/src/model/fluent.h
+++ b/src/model/fluent.h
@@ -70,7 +70,7 @@ class Fluent
 , public LanguageElement<Fluent>
 {
 public:
-	Fluent(Scope *own_scope, const string &type_name, const string &name, const vector<shared_ptr<Variable>> &params);
+	Fluent(Scope *own_scope, const Type &t, const string &name, const vector<shared_ptr<Variable>> &params);
 	//Fluent(Scope &parent_scope, const string &name);
 
 	virtual ~Fluent() override = default;

--- a/src/model/fluent.h
+++ b/src/model/fluent.h
@@ -64,7 +64,7 @@ private:
 
 
 class Fluent
-: public Global
+: public Signified<Expression>
 , public ScopeOwner
 , public virtual AbstractLanguageElement
 , public LanguageElement<Fluent>

--- a/src/model/formula.cpp
+++ b/src/model/formula.cpp
@@ -64,17 +64,17 @@ string Comparison::to_string(const string &pfx) const
 string to_string(ComparisonOperator op)
 {
 	switch (op) {
-	case NEQ:
+	case ComparisonOperator::NEQ:
 		return "!=";
-	case EQ:
+	case ComparisonOperator::EQ:
 		return "==";
-	case GE:
+	case ComparisonOperator::GE:
 		return ">=";
-	case GT:
+	case ComparisonOperator::GT:
 		return ">";
-	case LE:
+	case ComparisonOperator::LE:
 		return "<=";
-	case LT:
+	case ComparisonOperator::LT:
 		return "<";
 	}
 	return "[Unkown ComparisonOperator]";
@@ -111,15 +111,15 @@ string BooleanOperation::to_string(const string &pfx) const
 string to_string(BooleanOperator op)
 {
 	switch (op) {
-	case AND:
+	case BooleanOperator::AND:
 		return "&";
-	case OR:
+	case BooleanOperator::OR:
 		return "|";
-	case IFF:
+	case BooleanOperator::IFF:
 		return "==";
-	case IMPLIES:
+	case BooleanOperator::IMPLIES:
 		return "->";
-	case XOR:
+	case BooleanOperator::XOR:
 		return "!=";
 	}
 
@@ -131,9 +131,9 @@ string to_string(BooleanOperator op)
 string to_string(QuantificationOperator op)
 {
 	switch (op) {
-	case EXISTS:
+	case QuantificationOperator::EXISTS:
 		return "exists";
-	case FORALL:
+	case QuantificationOperator::FORALL:
 		return "forall";
 	}
 

--- a/src/model/formula.cpp
+++ b/src/model/formula.cpp
@@ -43,7 +43,14 @@ Comparison::Comparison(Expression *lhs, ComparisonOperator op, Expression *rhs)
 , op_(op)
 , rhs_(rhs)
 {
-	ensure_type_equality(*lhs, *rhs);
+	if (!(lhs->type() >= *rhs
+		|| lhs->type() <= rhs->type()
+		|| rhs->type() >= *lhs
+		|| rhs->type() <= lhs->type()
+	) )
+		throw TypeError("Incompatible types in comparison: "
+			+ lhs->type().name() + " and " + rhs->type().name()
+		);
 	lhs_->set_parent(this);
 	rhs_->set_parent(this);
 }

--- a/src/model/formula.h
+++ b/src/model/formula.h
@@ -45,19 +45,16 @@ protected:
 };
 
 
-enum ComparisonOperator {
-	EQ = 1, NEQ, GE, GT, LE, LT
-};
-
-
-string to_string(ComparisonOperator op);
-
 
 class Comparison : public Expression, public NoScopeOwner, public LanguageElement<Comparison, BoolType> {
 public:
-	Comparison(Expression *lhs, ComparisonOperator op, Expression *rhs);
+	enum Operator {
+		EQ = 1, NEQ, GE, GT, LE, LT
+	};
 
-	ComparisonOperator op() const;
+	Comparison(Expression *lhs, Operator op, Expression *rhs);
+
+	Operator op() const;
 	const Expression &lhs() const;
 	const Expression &rhs() const;
 
@@ -67,9 +64,13 @@ public:
 
 protected:
 	unique_ptr<Expression> lhs_;
-	ComparisonOperator op_;
+	Operator op_;
 	unique_ptr<Expression> rhs_;
 };
+
+using ComparisonOperator = Comparison::Operator;
+
+string to_string(Comparison::Operator op);
 
 
 
@@ -78,25 +79,23 @@ protected:
   Connective formulas, i.e. AND, OR, IMPLIES
 \*--------------------------------------------*/
 
-enum BooleanOperator {
-	// Order is important here since the
-	// enum value encodes operator precedence
-	IMPLIES = 0, OR, AND, XOR, IFF
-	, MIN_PRECEDENCE = IMPLIES
-	, MAX_PRECEDENCE = IFF
-};
-
-string to_string(BooleanOperator op);
-
 
 class BooleanOperation : public Expression, public NoScopeOwner, public LanguageElement<BooleanOperation, BoolType> {
 public:
+	enum Operator {
+		// Order is important here since the
+		// enum value encodes operator precedence
+		IMPLIES = 0, OR, AND, XOR, IFF
+		, MIN_PRECEDENCE = IMPLIES
+		, MAX_PRECEDENCE = IFF
+	};
+
 	BooleanOperation(
 		Expression *lhs,
-		BooleanOperator op,
+		Operator op,
 		Expression *rhs
 	);
-	BooleanOperator op() const;
+	Operator op() const;
 	const Expression &lhs() const;
 	const Expression &rhs() const;
 
@@ -106,9 +105,13 @@ public:
 
 protected:
 	SafeExprOwner<BoolType> lhs_;
-	BooleanOperator op_;
+	Operator op_;
 	SafeExprOwner<BoolType> rhs_;
 };
+
+using BooleanOperator = BooleanOperation::Operator;
+
+string to_string(BooleanOperator op);
 
 
 
@@ -116,24 +119,20 @@ protected:
   Set expressions & Quantifications
 \*--------------------------------------------*/
 
-
-enum QuantificationOperator {
-	EXISTS = 1, FORALL
-};
-
-string to_string(QuantificationOperator op);
-
-
 class Quantification : public Expression, public ScopeOwner, public LanguageElement<Quantification, BoolType> {
 public:
+	enum Operator {
+		EXISTS = 1, FORALL
+	};
+
 	Quantification(
 		Scope *own_scope,
-		QuantificationOperator op,
+		Operator op,
 		const shared_ptr<Variable> &variable,
 		Expression *expression
 	);
 
-	QuantificationOperator op() const;
+	Operator op() const;
 	const Variable &variable() const;
 	const Expression &expression() const;
 
@@ -142,10 +141,15 @@ public:
 	virtual string to_string(const string &pfx) const override;
 
 protected:
-	QuantificationOperator op_;
+	Operator op_;
 	shared_ptr<Variable> variable_;
 	SafeExprOwner<BoolType> expression_;
 };
+
+using QuantificationOperator = Quantification::Operator;
+
+string to_string(QuantificationOperator op);
+
 
 
 

--- a/src/model/global.h
+++ b/src/model/global.h
@@ -55,7 +55,7 @@ public:
 	Reference<Variable> *param_ref(const string &name);
 
 	virtual void compile(AExecutionContext &ctx) = 0;
-	virtual Expression *ref(const vector<Expression *> &params = {}) = 0;
+	virtual AbstractLanguageElement *ref(const vector<Expression *> &params = {}) = 0;
 
 	virtual Scope &parent_scope() override;
 	virtual const Scope &parent_scope() const override;
@@ -64,6 +64,19 @@ private:
 	vector<shared_ptr<Variable>> params_;
 };
 
+
+
+template<class T>
+class Signified
+: public Global
+{
+public:
+	using SignifierT = T;
+
+	using Global::Global;
+
+	virtual SignifierT *ref(const vector<Expression *> &params = {}) = 0;
+};
 
 
 } // namespace gologpp

--- a/src/model/gologpp.h
+++ b/src/model/gologpp.h
@@ -36,10 +36,11 @@ using fusion_wtf_vector = boost::fusion::vector2<T1, T2>;
 #endif
 
 
-class Expression;
-
-
 using string = std::string;
+
+
+class Expression;
+class Instruction;
 
 class AbstractLanguageElement;
 template<class, class> class LanguageElement;
@@ -90,7 +91,7 @@ class Quantification;
 
 class Block;
 class Choose;
-class Conditional;
+template<class> class Conditional;
 class Concurrent;
 template<class> class Assignment;
 class Pick;
@@ -109,6 +110,7 @@ class ListPush;
 class During;
 
 class Function;
+class Procedure;
 
 class AbstractReference;
 template<class> class Reference;
@@ -149,17 +151,21 @@ class PlatformBackend;
 	(Reference<Fluent>) \
 	(Reference<Variable>) \
 	(Reference<Function>) \
+	(Reference<Procedure>) \
 	(Pick)(Return) \
 	(FieldAccess) \
 	(ListAccess)(ListLength) \
 	(ListPop)(ListPush) \
 	(Domain) \
 	(Function) \
+	(Procedure) \
 	(Action)(Activity)(Transition) \
 	(ExogAction)(ExogEvent) \
 	(Scope)(ArithmeticOperation) \
 	(Negation)(BooleanOperation)(Quantification)(Concurrent) \
-	(Block)(Choose)(Conditional)(Search)(Solve)(Test)(While) \
+	(Block)(Choose)(Search)(Solve)(Test)(While) \
+	(Conditional<Instruction>) \
+	(Conditional<Expression>) \
 	(During) \
 	(History)(Reference<Action>) \
 	(Reference<ExogAction>) \

--- a/src/model/language.h
+++ b/src/model/language.h
@@ -69,6 +69,7 @@ public:
 	void set_type_by_name(const string &name);
 	void set_type(const Type &t);
 	virtual const Type &type() const;
+	shared_ptr<const Type> type_ptr() const;
 
 	// Unambiguous alias name to simplify type resolution for phoenix::bind in the parser
 	Scope &m_scope();
@@ -84,8 +85,12 @@ public:
 
 	void ensure_type(const Type &t);
 
+
 protected:
-	void set_type_unchecked(const string &name);
+	void set_type_unchecked(const Type &t);
+
+	template<class TypeT>
+	void t_set_type_unchecked();
 
 	unique_ptr<AbstractSemantics<AbstractLanguageElement>> semantics_;
 
@@ -104,7 +109,7 @@ public:
 	LanguageElement()
 	{
 		if (typeid(TypeT) != typeid(UndefinedType))
-			set_type_unchecked(TypeT::name());
+			t_set_type_unchecked<TypeT>();
 	}
 
 	virtual ~LanguageElement() = default;

--- a/src/model/list_expression.cpp
+++ b/src/model/list_expression.cpp
@@ -21,18 +21,18 @@ namespace gologpp {
 
 
 ListExpression::ListExpression(
-	const string &type_name,
+	const Type &t,
 	const boost::optional<vector<Expression *>> &entries
 )
 {
-	set_type_unchecked(type_name);
+	set_type_unchecked(t);
 
 	if (!AbstractLanguageElement::type().is<ListType>())
 		throw TypeError("Attempt to construct ListExpression, but type name \""
-			+ type_name + "\" does not refer to a list type");
+			+ t.name() + "\" does not refer to a list type");
 
 	for (Expression *expr : entries.get_value_or({})) {
-		if (type().element_type() == expr->type())
+		if (type().element_type() >= expr->type())
 			entries_.emplace_back(expr);
 		else
 			throw ExpressionTypeMismatch("Cannot assign " + expr->str()

--- a/src/model/list_expression.h
+++ b/src/model/list_expression.h
@@ -37,7 +37,7 @@ class ListExpression
 , public NoScopeOwner
 {
 public:
-	ListExpression(const string &type_name, const boost::optional<vector<Expression *>> &entries);
+	ListExpression(const Type &type, const boost::optional<vector<Expression *>> &entries);
 
 	const Expression &entry(size_t idx) const;
 	size_t size() const;

--- a/src/model/procedural.cpp
+++ b/src/model/procedural.cpp
@@ -184,7 +184,9 @@ Pick::Pick(
 {
 	if (domain)
 		for (Value *c : *domain) {
-			ensure_type_equality(*variable, *c);
+			if (!(variable->type() >= *c))
+				throw TypeError(*c, variable->type());
+
 			c->set_parent(this);
 			domain_.emplace_back(c);
 		}
@@ -328,24 +330,24 @@ string Return::to_string(const string &pfx) const
 
 Function::Function(
 	Scope *own_scope,
-	const string &type_name,
+	const Type &t,
 	const string &name,
 	const vector<shared_ptr<Variable>> &args
 )
 : ScopeOwner(own_scope)
 , Signified<Expression>(name, args)
-{ set_type_by_name(type_name); }
+{ set_type(t); }
 
 
 Function::Function(
 	Scope *own_scope,
-	const string &type_name,
+	const Type &t,
 	const string &name,
 	const boost::optional<vector<shared_ptr<Variable>>> &args
 )
 : ScopeOwner(own_scope)
 , Signified<Expression>(name, args.get_value_or({}))
-{ set_type_by_name(type_name); }
+{ set_type(t); }
 
 
 string Function::to_string(const string &pfx) const
@@ -378,24 +380,24 @@ const Expression &Function::definition() const
 
 Procedure::Procedure(
 	Scope *own_scope,
-	const string &type_name,
+	const Type &t,
 	const string &name,
 	const vector<shared_ptr<Variable>> &args
 )
 : ScopeOwner(own_scope)
 , Signified<Instruction>(name, args)
-{ set_type_by_name(type_name); }
+{ set_type(t); }
 
 
 Procedure::Procedure(
 	Scope *own_scope,
-	const string &type_name,
+	const Type &t,
 	const string &name,
 	const boost::optional<vector<shared_ptr<Variable>>> &args
 )
 : ScopeOwner(own_scope)
 , Signified<Instruction>(name, args.get_value_or({}))
-{ set_type_by_name(type_name); }
+{ set_type(t); }
 
 
 void Procedure::define(Instruction *definition)

--- a/src/model/procedural.cpp
+++ b/src/model/procedural.cpp
@@ -29,10 +29,10 @@
 namespace gologpp {
 
 
-Block::Block(Scope *own_scope, const vector<Expression *> &elements)
+Block::Block(Scope *own_scope, const vector<Instruction *> &elements)
 : ScopeOwner(own_scope)
 {
-	for (Expression *stmt : elements) {
+	for (Instruction *stmt : elements) {
 		stmt->set_parent(this);
 		elements_.emplace_back(stmt);
 	}
@@ -48,7 +48,7 @@ void Block::attach_semantics(SemanticsFactory &f)
 	}
 }
 
-const vector<SafeExprOwner<VoidType>> &Block::elements() const
+const vector<unique_ptr<Instruction>> &Block::elements() const
 { return elements_; }
 
 string Block::to_string(const string &pfx) const
@@ -66,16 +66,16 @@ string Block::to_string(const string &pfx) const
 
 
 
-Choose::Choose(Scope *own_scope, const vector<Expression *> &alternatives)
+Choose::Choose(Scope *own_scope, const vector<Instruction *> &alternatives)
 : ScopeOwner(own_scope)
 {
-	for (Expression *stmt : alternatives) {
+	for (Instruction *stmt : alternatives) {
 		stmt->set_parent(this);
 		alternatives_.emplace_back(stmt);
 	}
 }
 
-const vector<SafeExprOwner<VoidType>> &Choose::alternatives() const
+const vector<unique_ptr<Instruction>> &Choose::alternatives() const
 { return alternatives_; }
 
 
@@ -84,7 +84,7 @@ void Choose::attach_semantics(SemanticsFactory &f)
 	if (!semantics_) {
 		semantics_ = f.make_semantics(*this);
 		scope().attach_semantics(f);
-		for (SafeExprOwner<VoidType> &stmt : alternatives_)
+		for (unique_ptr<Instruction> &stmt : alternatives_)
 			stmt->attach_semantics(f);
 	}
 }
@@ -98,11 +98,11 @@ string Choose::to_string(const string &pfx) const
 }
 
 
-
-Conditional::Conditional(
+template<class SignT>
+Conditional<SignT>::Conditional(
 	Expression *condition,
-	Expression *block_true,
-	Expression *block_false
+	SignT *block_true,
+	SignT *block_false
 )
 : condition_(condition)
 , block_true_(block_true)
@@ -113,28 +113,38 @@ Conditional::Conditional(
 	block_false_->set_parent(this);
 }
 
-const Expression &Conditional::condition() const
+template<class SignT>
+const Expression &Conditional<SignT>::condition() const
 { return *condition_; }
 
-const Expression &Conditional::block_false() const
+template<class SignT>
+const SignT &Conditional<SignT>::block_false() const
 { return *block_false_; }
 
-const Expression &Conditional::block_true() const
+template<class SignT>
+const SignT &Conditional<SignT>::block_true() const
 { return *block_true_; }
 
 
-string Conditional::to_string(const string &pfx) const
+template<class SignT>
+string Conditional<SignT>::to_string(const string &pfx) const
 {
 	return linesep + pfx + "if (" + condition().to_string("") + ") " + block_true().to_string(pfx)
 		+ (block_false_ ? pfx + linesep + "else" + block_false().to_string(pfx) : "");
 }
 
+template
+class Conditional<Instruction>;
+
+template
+class Conditional<Expression>;
 
 
-Concurrent::Concurrent(Scope *own_scope, const vector<Expression *> &procs)
+
+Concurrent::Concurrent(Scope *own_scope, const vector<Instruction *> &procs)
 : ScopeOwner(own_scope)
 {
-	for (Expression *p : procs) {
+	for (Instruction *p : procs) {
 		p->set_parent(this);
 		procs_.emplace_back(p);
 	}
@@ -145,11 +155,11 @@ void Concurrent::attach_semantics(SemanticsFactory &f)
 {
 	semantics_ = f.make_semantics(*this);
 	scope().attach_semantics(f);
-	for (SafeExprOwner<VoidType> &p : procs_)
+	for (unique_ptr<Instruction> &p : procs_)
 		p->attach_semantics(f);
 }
 
-const vector<SafeExprOwner<VoidType>> &Concurrent::procs() const
+const vector<unique_ptr<Instruction>> &Concurrent::procs() const
 { return procs_; }
 
 
@@ -166,7 +176,7 @@ Pick::Pick(
 	Scope *own_scope,
 	const shared_ptr<Variable> &variable,
 	const boost::optional<std::vector<Value *>> &domain,
-	Expression *statement
+	Instruction *statement
 )
 : ScopeOwner(own_scope)
 , variable_(variable)
@@ -189,7 +199,7 @@ const vector<unique_ptr<Value>> &Pick::domain() const
 const Variable &Pick::variable() const
 { return *variable_; }
 
-const Expression &Pick::statement() const
+const Instruction &Pick::statement() const
 { return *statement_; }
 
 string Pick::to_string(const string &pfx) const
@@ -213,13 +223,13 @@ void Pick::attach_semantics(SemanticsFactory &f)
 
 
 
-Search::Search(Expression *statement)
+Search::Search(Instruction *statement)
 : statement_(statement)
 {
 	statement_->set_parent(this);
 }
 
-const Expression &Search::statement() const
+const Instruction &Search::statement() const
 { return *statement_; }
 
 string Search::to_string(const string &pfx) const
@@ -230,7 +240,7 @@ string Search::to_string(const string &pfx) const
 Solve::Solve(
 	Expression *horizon,
 	Reference<Function> *reward,
-	Expression *statement
+	Instruction *statement
 )
 : statement_(statement)
 , horizon_(horizon)
@@ -240,7 +250,7 @@ Solve::Solve(
 	reward_->set_parent(this);
 }
 
-const Expression &Solve::statement() const
+const Instruction &Solve::statement() const
 { return *statement_; }
 
 const Expression &Solve::horizon() const
@@ -285,7 +295,7 @@ string Test::to_string(const string &pfx) const
 
 
 
-While::While(Expression *expression, Expression *statement)
+While::While(Expression *expression, Instruction *statement)
 : expression_(expression)
 , statement_(statement)
 {
@@ -296,7 +306,7 @@ While::While(Expression *expression, Expression *statement)
 const Expression &While::expression() const
 { return *expression_; }
 
-const Expression &While::statement() const
+const Instruction &While::statement() const
 { return *statement_; }
 
 string While::to_string(const string &pfx) const
@@ -322,8 +332,8 @@ Function::Function(
 	const string &name,
 	const vector<shared_ptr<Variable>> &args
 )
-: Global(name, args)
-, ScopeOwner(own_scope)
+: ScopeOwner(own_scope)
+, Signified<Expression>(name, args)
 { set_type_by_name(type_name); }
 
 
@@ -333,13 +343,24 @@ Function::Function(
 	const string &name,
 	const boost::optional<vector<shared_ptr<Variable>>> &args
 )
-: Global(name, args.get_value_or({}))
-, ScopeOwner(own_scope)
+: ScopeOwner(own_scope)
+, Signified<Expression>(name, args.get_value_or({}))
 { set_type_by_name(type_name); }
 
 
-const Expression &Function::definition() const
-{ return *definition_; }
+string Function::to_string(const string &pfx) const
+{
+	return linesep + pfx + type().name() + " function " + name() + '('
+	+ concat_list(params(), ", ")
+	+ ") " + definition().to_string(pfx);
+}
+
+void Function::define(Expression *definition)
+{
+	definition_.reset(definition);
+	definition_->set_parent(this);
+}
+
 
 void Function::compile(AExecutionContext &ctx)
 { ctx.compile(*this); }
@@ -350,26 +371,61 @@ Reference<Function> *Function::make_ref(const vector<Expression *> &args)
 Expression *Function::ref(const vector<Expression *> &args)
 { return make_ref(args); }
 
+const Expression &Function::definition() const
+{ return *definition_; }
 
-void Function::define(Expression *definition)
+
+
+Procedure::Procedure(
+	Scope *own_scope,
+	const string &type_name,
+	const string &name,
+	const vector<shared_ptr<Variable>> &args
+)
+: ScopeOwner(own_scope)
+, Signified<Instruction>(name, args)
+{ set_type_by_name(type_name); }
+
+
+Procedure::Procedure(
+	Scope *own_scope,
+	const string &type_name,
+	const string &name,
+	const boost::optional<vector<shared_ptr<Variable>>> &args
+)
+: ScopeOwner(own_scope)
+, Signified<Instruction>(name, args.get_value_or({}))
+{ set_type_by_name(type_name); }
+
+
+void Procedure::define(Instruction *definition)
 {
-	definition_ = definition;
+	definition_.reset(definition);
 	definition_->set_parent(this);
 }
 
 
-string Function::to_string(const string &pfx) const
+string Procedure::to_string(const string &pfx) const
 {
-	string fn;
-	if (type() == gologpp::type<VoidType>())
-		fn = "procedure ";
-	else
-		fn = type().name() + " function ";
-
-	return linesep + pfx + fn + name() + '('
+	return linesep + pfx + "procedure " + name() + '('
 	+ concat_list(params(), ", ")
 	+ ") " + definition().to_string(pfx);
 }
+
+
+void Procedure::compile(AExecutionContext &ctx)
+{ ctx.compile(*this); }
+
+Reference<Procedure> *Procedure::make_ref(const vector<Expression *> &args)
+{ return make_ref_<Procedure>(args); }
+
+Instruction *Procedure::ref(const vector<Expression *> &args)
+{ return make_ref(args); }
+
+const Instruction &Procedure::definition() const
+{ return *definition_; }
+
+
 
 
 
@@ -515,9 +571,9 @@ string ListPush::to_string(const string &pfx) const
 
 During::During(
 	Reference<Action> *action_call,
-	Expression *parallel_block,
-	boost::optional<Expression *> on_fail,
-	boost::optional<Expression *> on_cancel
+	Instruction *parallel_block,
+	boost::optional<Instruction *> on_fail,
+	boost::optional<Instruction *> on_cancel
 )
 : action_call_(action_call)
 , parallel_block_(parallel_block)
@@ -543,13 +599,13 @@ During::During(
 const Reference<Action> &During::action_call() const
 { return *action_call_; }
 
-const Expression &During::parallel_block() const
+const Instruction &During::parallel_block() const
 { return *parallel_block_; }
 
-const Expression &During::on_fail() const
+const Instruction &During::on_fail() const
 { return *on_fail_; }
 
-const Expression &During::on_cancel() const
+const Instruction &During::on_cancel() const
 { return *on_cancel_; }
 
 string During::to_string(const string &pfx) const

--- a/src/model/procedural.h
+++ b/src/model/procedural.h
@@ -169,7 +169,9 @@ public:
 		if (lhs_->type().template is<VoidType>())
 			throw TypeError("Cannot assign to a void expression");
 
-		ensure_type_equality(*lhs, *rhs);
+		if (!(lhs_->type() >= *rhs))
+			throw TypeError(*rhs, lhs_->type());
+
 		lhs_->set_parent(this);
 		rhs_->set_parent(this);
 	}
@@ -334,14 +336,14 @@ class Procedure
 public:
 	Procedure(
 		Scope *own_scope,
-		const string &type_name,
+		const Type &t,
 		const string &name,
 		const vector<shared_ptr<Variable>> &params
 	);
 
 	Procedure(
 		Scope *own_scope,
-		const string &type_name,
+		const Type &t,
 		const string &name,
 		const boost::optional<vector<shared_ptr<Variable>>> &params
 	);
@@ -372,14 +374,14 @@ class Function
 public:
 	Function(
 		Scope *own_scope,
-		const string &type_name,
+		const Type &t,
 		const string &name,
 		const vector<shared_ptr<Variable>> &params
 	);
 
 	Function(
 		Scope *own_scope,
-		const string &type_name,
+		const Type &t,
 		const string &name,
 		const boost::optional<vector<shared_ptr<Variable>>> &params
 	);

--- a/src/model/reference.h
+++ b/src/model/reference.h
@@ -58,8 +58,7 @@ using ParamsToArgs = std::unordered_map<
 
 template<class TargetT, class ArgsT>
 class ReferenceBase
-: public Expression
-, public virtual AbstractReference
+: public virtual AbstractReference
 , public NoScopeOwner
 {
 public:
@@ -232,6 +231,7 @@ template<class TargetT>
 class Reference
 : public ReferenceBase<TargetT, Expression>
 , public LanguageElement<Reference<TargetT>>
+, public TargetT::SignifierT
 {
 public:
 	using ReferenceBase<TargetT, Expression>::ReferenceBase;

--- a/src/model/reference.h
+++ b/src/model/reference.h
@@ -176,7 +176,7 @@ public:
 		for (; it_rarg < args().end() && it_targ < target()->params().end(); ++it_rarg, ++it_targ) {
 			const Type &t_ref = (*it_rarg)->type();
 			const Type &t_tgt = (*it_targ)->type();
-			if (t_ref != t_tgt
+			if (!(t_tgt >= **it_rarg)
 				&& !(t_ref.is<SymbolType>() && t_tgt.is<StringType>())
 				// TODO: Hack: Allow passing a symbol value to a string argument
 				// This is needed because ReadyLog can't deal with strings.
@@ -317,10 +317,6 @@ public:
 
 	Reference(Reference<Variable> &&other)
 	: target_(std::move(other.target_))
-	{}
-
-	Reference(const string &var_name)
-	: target_(global_scope().get_var(VarDefinitionMode::DENY, "", var_name))
 	{}
 
 	virtual ~Reference() override = default;

--- a/src/model/scope.cpp
+++ b/src/model/scope.cpp
@@ -31,18 +31,6 @@ namespace gologpp {
 Scope Scope::global_scope_;
 
 
-Expression *ref_to_global(
-	const string &name,
-	const boost::optional<vector<Expression *>> &args
-) {
-	return global_scope().lookup_global(
-		name,
-		arity_t(args ? args->size() : 0)
-	)->ref(args.get_value_or({}));
-}
-
-
-
 Scope &NoScopeOwner::scope()
 { return parent_scope(); }
 

--- a/src/model/scope.h
+++ b/src/model/scope.h
@@ -38,13 +38,6 @@ Scope &global_scope();
 
 
 
-Expression *ref_to_global(
-	const string &name,
-	const boost::optional<vector<Expression *>> &args
-);
-
-
-
 /**
  * @brief The NoScopeOwner class: A language element that does not open a new scope,
  * i.e. its scope and the scope of its children is its parent scope.

--- a/src/model/semantics.cpp
+++ b/src/model/semantics.cpp
@@ -23,6 +23,9 @@ namespace gologpp {
 AbstractSemantics<AbstractLanguageElement>::AbstractSemantics()
 {}
 
+Instruction *gologpp::AbstractSemantics<Instruction>::plan(History &h)
+{ return trans(h); }
+
 
 }
 

--- a/src/model/semantics.h
+++ b/src/model/semantics.h
@@ -38,6 +38,7 @@ public:
 };
 
 
+
 template<>
 class AbstractSemantics<Expression>
 : public virtual AbstractSemantics<AbstractLanguageElement>
@@ -45,6 +46,18 @@ class AbstractSemantics<Expression>
 public:
 	virtual Value evaluate(const Activity &context, const History &h) = 0;
 };
+
+
+
+template<>
+class AbstractSemantics<Instruction>
+: public virtual AbstractSemantics<AbstractLanguageElement>
+{
+public:
+	virtual Instruction *trans(History &h) = 0;
+	virtual Instruction *plan(History &h);
+};
+
 
 
 template<class GologT>

--- a/src/model/types.cpp
+++ b/src/model/types.cpp
@@ -21,28 +21,18 @@
 namespace gologpp {
 
 
-void ensure_type_equality(const AbstractLanguageElement &e1, const AbstractLanguageElement &e2)
-{
-	if (e1.type() != e2.type())
-		throw ExpressionTypeMismatch(e1, e2);
-}
-
-
 Type::Type(const string &name)
-: Name(name)
+: name_(name)
 {}
 
-bool Type::operator == (const Type &other) const
-{ return this == &other || typeid(*this) == typeid(other) || other.is<UndefinedType>(); }
+bool Type::operator >= (const Type &other) const
+{ return this == &other || name() == other.name() || other.is<UndefinedType>(); }
 
-bool Type::operator == (const string &type_name) const
-{ return name() == type_name || type_name == UndefinedType::name(); }
+bool Type::operator >= (const AbstractLanguageElement &e) const
+{ return *this >= e.type(); }
 
-bool Type::operator != (const Type &other) const
-{ return !(*this == other); }
-
-bool Type::operator != (const string &type_name) const
-{ return !(*this == type_name); }
+bool Type::operator <= (const Type &other) const
+{ return other >= *this; }
 
 Type::operator bool () const
 { return true; }
@@ -53,22 +43,25 @@ bool Type::is_compound() const
 bool Type::is_simple() const
 { return !is_compound(); }
 
-void Type::ensure_match(const AbstractLanguageElement &e) const
-{
-	if (e.type() == *this)
-		throw ExpressionTypeMismatch(e.str() + " does not match type " + name());
-}
+string Type::name() const
+{ return name_; }
+
+Type::operator string () const
+{ return name_; }
 
 
 
 UndefinedType::UndefinedType()
-: Type(name())
+: Type(static_name())
 {}
 
-bool UndefinedType::operator == (const Type &) const
+bool UndefinedType::operator >= (const Type &) const
 { return true; }
 
-bool UndefinedType::operator == (const string &) const
+bool UndefinedType::operator >= (const AbstractLanguageElement &) const
+{ return true; }
+
+bool UndefinedType::operator <= (const Type &) const
 { return true; }
 
 bool UndefinedType::is_simple() const
@@ -77,53 +70,53 @@ bool UndefinedType::is_simple() const
 UndefinedType::operator bool () const
 { return false; }
 
-string UndefinedType::name()
+string UndefinedType::static_name()
 { return "~undefined~"; }
 
 
 
 
 BoolType::BoolType()
-: Type(name())
+: Type(static_name())
 {}
 
-string BoolType::name()
+string BoolType::static_name()
 { return "bool"; }
 
 
 
 NumberType::NumberType()
-: Type(name())
+: Type(static_name())
 {}
 
-string NumberType::name()
+string NumberType::static_name()
 { return "number"; }
 
 
 
 StringType::StringType()
-: Type(name())
+: Type(static_name())
 {}
 
-string StringType::name()
+string StringType::static_name()
 { return "string"; }
 
 
 
 SymbolType::SymbolType()
-: Type(name())
+: Type(static_name())
 {}
 
-string SymbolType::name()
+string SymbolType::static_name()
 { return "symbol"; }
 
 
 
 VoidType::VoidType()
-: Type(name())
+: Type(static_name())
 {}
 
-string VoidType::name()
+string VoidType::static_name()
 { return "void"; }
 
 
@@ -132,20 +125,20 @@ CompoundType::CompoundType(const string &name)
 : Type(name)
 {}
 
-string CompoundType::name()
+string CompoundType::static_name()
 { return "compound"; }
 
 
-void CompoundType::add_field(const string &name, const string &type)
+void CompoundType::add_field(const string &name, const Type &type)
 {
 	if (has_field(name))
 		throw UserError("compound type `" + this->name() + "': duplicate field name: `" + name + "'");
 
-	fields_.insert({name, global_scope().lookup_type(type)});
+	fields_.insert({name, type.shared_from_this()});
 }
 
-bool CompoundType::has_field_of_type(const string &field_name, const string &type_name) const
-{ return has_field(field_name) && field_type(field_name) == type_name; }
+bool CompoundType::has_field_of_type(const string &field_name, const Type &type) const
+{ return has_field(field_name) && field_type(field_name) >= type; }
 
 bool CompoundType::has_field(const string &name) const
 { return fields_.find(name) != fields_.end(); }
@@ -160,15 +153,12 @@ std::unordered_set<string> CompoundType::field_names() const
 }
 
 
-bool CompoundType::operator == (const Type &other) const
+bool CompoundType::operator >= (const Type &other) const
 {
-	if (other.is<UndefinedType>())
-		return true;
-
 	try {
 		const CompoundType &o = dynamic_cast<const CompoundType &>(other);
 		for (auto pair : fields_) {
-			if (o.field_type(pair.first) != *pair.second)
+			if (!(o.field_type(pair.first) >= *pair.second))
 				return false;
 		}
 		return true;
@@ -177,8 +167,6 @@ bool CompoundType::operator == (const Type &other) const
 	}
 }
 
-bool CompoundType::operator == (const string &type_name) const
-{ return name() == type_name || type_name == CompoundType::name() || type_name == UndefinedType::name(); }
 
 bool CompoundType::is_compound() const
 { return true; }
@@ -194,17 +182,24 @@ ListType::ListType(const string &elem_type_name)
 : ListType(*global_scope().lookup_type<Type>(elem_type_name))
 {}
 
-string ListType::name()
+string ListType::static_name()
 { return "list"; }
 
 const Type &ListType::element_type() const
 { return elem_type_; }
 
-bool ListType::operator == (const Type &other) const
-{ return other.is<ListType>() || Type::operator == (other); }
+PType ListType::element_type_ptr() const
+{ return elem_type_.shared_from_this(); }
 
-bool ListType::operator == (const string &other) const
-{ return other == ListType::name() || Type::operator == (other); }
+bool ListType::operator >= (const Type &other) const
+{
+	try {
+		const ListType &t = dynamic_cast<const ListType &>(other);
+		return this->element_type() >= t.element_type();
+	} catch (std::bad_cast &) {
+		return false;
+	}
+}
 
 bool ListType::is_compound() const
 { return false; }

--- a/src/model/utilities.cpp
+++ b/src/model/utilities.cpp
@@ -23,10 +23,6 @@ Name::Name(const string &name)
 : name_(name)
 {}
 
-Name::Name(Name &&other)
-: name_(std::move(other.name_))
-{}
-
 Name::operator string () const
 { return name_; }
 

--- a/src/model/utilities.h
+++ b/src/model/utilities.h
@@ -182,6 +182,16 @@ string concat_list(const ListT &l, const string sep, const string &pfx = "")
 }
 
 
+template<class T, class T1, class... Ts>
+struct is_member {
+	static constexpr bool value()
+	{ return std::is_same<T, T1>::value || (sizeof...(Ts) && is_member<T, Ts...>::value()); }
+};
+
+
+
+
+
 } // namespace gologpp
 
 

--- a/src/model/utilities.h
+++ b/src/model/utilities.h
@@ -29,16 +29,14 @@ namespace gologpp {
 class Name {
 public:
     Name(const string &name);
-    Name(Name &&other);
-    Name(const Name &other) = default;
     virtual ~Name() = default;
     
-    explicit operator string () const;
-    const string &name() const;
+    operator string () const;
     virtual bool operator == (const Name &other) const;
     bool operator != (const Name &other) const;
     virtual size_t hash() const;
-    
+    const string &name() const;
+
 protected:
     string name_;
 };

--- a/src/model/value.h
+++ b/src/model/value.h
@@ -68,12 +68,12 @@ public:
 	// For ReprT = const char * there is an explicit specialization since it would be
 	// converted to bool otherwise (see below and in .cpp).
 	template<class ReprT>
-	explicit Value(const string &type_name, ReprT repr) : representation_(repr) {
-		set_type_by_name(type_name);
+	explicit Value(const Type &type, ReprT repr) : representation_(repr) {
+		set_type(type);
 	}
 
-	Value(const string &type_name, const vector<fusion_wtf_vector<string, Value *>> &compound_values);
-	Value(const string &type_name, const boost::optional<vector<Value *>> &list_values);
+	Value(const Type &type, const vector<fusion_wtf_vector<string, Value *>> &compound_values);
+	Value(const Type &type, const boost::optional<vector<Value *>> &list_values);
 	Value(Value &&c);
 	Value(const Value &c);
 	explicit Value();
@@ -162,7 +162,7 @@ private:
 
 
 template<>
-Value::Value(const string &type_name, const char *repr);
+Value::Value(const Type &type, const char *repr);
 
 
 vector<unique_ptr<Value>> copy(const vector<unique_ptr<Value>> &v);

--- a/src/model/value.h
+++ b/src/model/value.h
@@ -135,6 +135,13 @@ public:
 
 	virtual bool operator == (const Value &c) const;
 
+	bool operator >= (const Value &) const;
+	bool operator <= (const Value &) const;
+	bool operator > (const Value &) const;
+	bool operator < (const Value &) const;
+
+	Value operator ! () const;
+
 	bool operator != (const Value &) const;
 	virtual Value *copy() const;
 

--- a/src/model/variable.cpp
+++ b/src/model/variable.cpp
@@ -21,11 +21,16 @@
 namespace gologpp {
 
 
-Variable::Variable(const string &type_name, const string &name)
+Variable::Variable(const Type &t, const string &name)
 : Identifier(name, 0)
-, domain_(new Domain(type_name))
 {
-	set_type_by_name(type_name);
+	set_type(t);
+
+	if (t.is<Domain>())
+		domain_ = global_scope().lookup_domain(t.name(), t);
+	else
+		domain_.reset(new Domain(t));
+
 	domain_->add_subject(*this);
 }
 
@@ -55,7 +60,7 @@ void Variable::add_implicit_domain_element(const Value &c)
 
 void Variable::set_domain(const string &domain_name)
 {
-	domain_ = global_scope().lookup_domain(domain_name);
+	domain_ = global_scope().lookup_domain(domain_name, type());
 	domain_->add_subject(*this);
 }
 
@@ -72,7 +77,7 @@ void Variable::set_domain_copy(const Domain &domain)
 
 void Variable::define_implicit_domain(const string &domain_name)
 {
-	global_scope().register_domain(new Domain(domain_name, type().name(), {}, true));
+	global_scope().register_domain_raw(new Domain(domain_name, type(), {}, true));
 	set_domain(domain_name);
 }
 

--- a/src/model/variable.h
+++ b/src/model/variable.h
@@ -36,7 +36,7 @@ class Variable
 , public std::enable_shared_from_this<Variable>
 {
 protected:
-	Variable(const string &type_name, const string &name);
+	Variable(const Type &type, const string &name);
 
 public:
 	virtual ~Variable() override = default;

--- a/src/parser/action.cpp
+++ b/src/parser/action.cpp
@@ -65,7 +65,6 @@ ActionDefinitionParser<Action>::ActionDefinitionParser()
 		( "precondition:" > boolean_expression(*_r2) )
 		^ ( "effect:" > +(effect(*_r2) > ';') )
 		^ ( "senses:" > senses(*_r2) )
-		^ ( "domain:" > +(domain_assignment()(*_r2, false)) )
 		^ ( "mapping:" > mapping(*_r2) )
 		^ qi::eps
 	) > '}' ) [
@@ -78,7 +77,7 @@ ActionDefinitionParser<Action>::ActionDefinitionParser()
 				boost::optional<ActionMapping *>
 			>,
 			_r1,
-			_r2, val(""), _r3, _r4, _1, _2, _3, _4
+			_r2, undefined_type(), _r3, _r4, _1, _2, _3, _4
 		)
 	];
 
@@ -98,7 +97,6 @@ ActionDefinitionParser<ExogAction>::ActionDefinitionParser()
 	definition = ( lit('{') > (
 		( "precondition:" > boolean_expression(*_r2) )
 		^ ( "effect:" > +(effect(*_r2) > ';') )
-		^ ( "domain:" > +(domain_assignment()(*_r2, false)) )
 		^ ( "mapping:" > mapping(*_r2) )
 		^ qi::eps
 	) > '}' ) [
@@ -110,7 +108,7 @@ ActionDefinitionParser<ExogAction>::ActionDefinitionParser()
 				boost::optional<ActionMapping *>
 			>,
 			_r1,
-			_r2, val(""), _r3, _r4, _1, _2, _3
+			_r2, undefined_type(), _r3, _r4, _1, _2, _3
 		)
 	];
 
@@ -139,7 +137,7 @@ ActionParser<ActionT>::ActionParser()
 	> (
 		action_definition(_r1, _a, _b, _c)
 		| lit(';') [
-			phoenix::bind(&Scope::declare_global<ActionT>, _r1, _a, val(""), _b, _c)
+			phoenix::bind(&Scope::declare_global<ActionT>, _r1, _a, undefined_type(), _b, _c)
 		]
 	);
 	action.name("action_declaration");

--- a/src/parser/arithmetic.cpp
+++ b/src/parser/arithmetic.cpp
@@ -51,14 +51,14 @@ NumericExpressionParser::NumericExpressionParser()
 	unary_expr = brace(_r1) | numeric_value()
 		| num_var_ref(_r1)
 		| list_length(_r1)
-		| conditional_expression(_r1, NumberType::name())
-		| typed_reference<Fluent>()(_r1, NumberType::name())
-		| typed_reference<Function>()(_r1, NumberType::name())
-		| mixed_member_access()(_r1, NumberType::name())
+		| conditional_expression(_r1, number_type())
+		| typed_reference<Fluent>()(_r1, number_type())
+		| typed_reference<Function>()(_r1, number_type())
+		| mixed_member_access()(_r1, number_type())
 	;
 	unary_expr.name("unary_numeric_expression");
 
-	list_length = (lit("length") > '(' > list_expression(_r1) > ')') [
+	list_length = (lit("length") > '(' > list_expression(_r1, undefined_type()) > ')') [
 		_val = new_<ListLength>(_1)
 	];
 
@@ -82,7 +82,7 @@ NumericExpressionParser::NumericExpressionParser()
 	;
 	arith_operator.name("arithmetic_operator");
 
-	num_var_ref = var_usage()(_r1, NumberType::name()) [
+	num_var_ref = var_usage()(_r1, number_type()) [
 		_val = new_<Reference<Variable>>(_1)
 	];
 	num_var_ref.name("reference_to_numeric_variable");

--- a/src/parser/arithmetic.cpp
+++ b/src/parser/arithmetic.cpp
@@ -20,6 +20,7 @@
 #include "value.h"
 #include "list_expression.h"
 #include "mixed_member_access.h"
+#include "expressions.h"
 
 #include <model/fluent.h>
 #include <model/procedural.h>
@@ -50,6 +51,7 @@ NumericExpressionParser::NumericExpressionParser()
 	unary_expr = brace(_r1) | numeric_value()
 		| num_var_ref(_r1)
 		| list_length(_r1)
+		| conditional_expression(_r1, NumberType::name())
 		| typed_reference<Fluent>()(_r1, NumberType::name())
 		| typed_reference<Function>()(_r1, NumberType::name())
 		| mixed_member_access()(_r1, NumberType::name())

--- a/src/parser/assignment.cpp
+++ b/src/parser/assignment.cpp
@@ -47,9 +47,9 @@ AssignmentParser<LhsT>::AssignmentParser()
 {
 	assignment = (
 		(lhs_parser(_r1) >> "=") [
-			_a = phoenix::bind(&Expression::type_name, *_1)
+			_a = phoenix::bind(&Expression::type_ptr, *_1)
 		]
-		> typed_expression()(_r1, _a)
+		> typed_expression()(_r1, *_a)
 	) [
 		_val = new_<Assignment<LhsT>>(_1, _2)
 	];
@@ -73,7 +73,7 @@ void AssignmentParser<Reference<Fluent>>::init()
 template<>
 void AssignmentParser<FieldAccess>::init()
 {
-	lhs_parser = mixed_member_access()(_r1, UndefinedType::name()) [
+	lhs_parser = mixed_member_access()(_r1, undefined_type()) [
 		_pass = (_val = dynamic_cast_<FieldAccess *>(_1))
 	];
 	lhs_parser.name("field_access_lhs");
@@ -83,7 +83,7 @@ void AssignmentParser<FieldAccess>::init()
 template<>
 void AssignmentParser<ListAccess>::init()
 {
-	lhs_parser = mixed_member_access()(_r1, UndefinedType::name()) [
+	lhs_parser = mixed_member_access()(_r1, undefined_type()) [
 		_pass = (_val = dynamic_cast_<ListAccess *>(_1))
 	];
 	lhs_parser.name("list_access_lhs");

--- a/src/parser/assignment.h
+++ b/src/parser/assignment.h
@@ -31,12 +31,12 @@ namespace parser {
 
 
 template<class LhsT>
-struct AssignmentParser : grammar<Assignment<LhsT> *(Scope &), locals<Typename>> {
+struct AssignmentParser : grammar<Assignment<LhsT> *(Scope &), locals<shared_ptr<const Type>>> {
 	AssignmentParser();
 
 	void init();
 
-	rule<Assignment<LhsT> *(Scope &), locals<Typename>> assignment;
+	rule<Assignment<LhsT> *(Scope &), locals<shared_ptr<const Type>>> assignment;
 	rule<LhsT *(Scope &)> lhs_parser;
 };
 

--- a/src/parser/compound_expression.cpp
+++ b/src/parser/compound_expression.cpp
@@ -67,6 +67,7 @@ void initialize_compound_exprs()
 
 	compound_expression =
 		mixed_member_access()(_r1, CompoundType::name()) [ _val = _1 ]
+		| conditional_expression(_r1, CompoundType::name()) [ _val = _1 ]
 		| compound_atom(_r1) [ _val = _1 ]
 		| braced_compound_expr_(_r1) [ _val = _1 ]
 		, "compound_expression"

--- a/src/parser/compound_expression.cpp
+++ b/src/parser/compound_expression.cpp
@@ -20,6 +20,7 @@
 #include "value.h"
 #include "variable.h"
 #include "expressions.h"
+#include "types.h"
 
 #include <model/fluent.h>
 #include <model/procedural.h>
@@ -36,6 +37,7 @@
 #include <boost/phoenix/object/dynamic_cast.hpp>
 #include <boost/phoenix/object/static_cast.hpp>
 #include <boost/phoenix/operator/self.hpp>
+#include <boost/phoenix/operator/comparison.hpp>
 #include <boost/phoenix/statement/if.hpp>
 #include <boost/phoenix/bind/bind_function.hpp>
 #include <boost/phoenix/bind/bind_member_function.hpp>
@@ -46,53 +48,56 @@ namespace parser {
 
 
 
-rule<Expression *(Scope &)> compound_atom;
+rule<Expression *(Scope &, const Type &)> compound_atom;
 
-rule<Expression *(Scope &)> compound_expression;
+rule<Expression *(Scope &, const Type &)> compound_expression;
 
-static rule<Expression *(Scope &), locals<shared_ptr<const CompoundType>, Typename>> braced_compound_expr_;
+static rule<Expression *(Scope &, const Type &), locals<shared_ptr<const CompoundType>, string>> braced_compound_expr_;
 
 
 void initialize_compound_exprs()
 {
 	compound_atom =
-		compound_value() [ _val = _1 ]
-		| typed_reference<Fluent>()(_r1, CompoundType::name()) [ _val = _1 ]
-		| typed_reference<Function>()(_r1, CompoundType::name()) [ _val = _1 ]
-		| var_usage()(_r1, val(CompoundType::name())) [
+		compound_value() [
+			_val = _1,
+			_pass = (*_val <= _r2)
+		]
+		| typed_reference<Fluent>()(_r1, _r2) [ _val = _1 ]
+		| typed_reference<Function>()(_r1, _r2) [ _val = _1 ]
+		| var_usage()(_r1, _r2) [
 			_val = new_<Reference<Variable>>(_1)
 		]
 		, "compound_atom"
 	;
 
 	compound_expression =
-		mixed_member_access()(_r1, CompoundType::name()) [ _val = _1 ]
-		| conditional_expression(_r1, CompoundType::name()) [ _val = _1 ]
-		| compound_atom(_r1) [ _val = _1 ]
-		| braced_compound_expr_(_r1) [ _val = _1 ]
+		mixed_member_access()(_r1, _r2) [ _val = _1 ]
+		| conditional_expression(_r1, _r2) [ _val = _1 ]
+		| compound_atom(_r1, _r2) [ _val = _1 ]
+		| braced_compound_expr_(_r1, _r2) [ _val = _1 ]
 		, "compound_expression"
 	;
 
 	braced_compound_expr_ =
 		(
-			(complex_type_identifier<CompoundType>()(_r1) [
-				_a = _1
+			(type_identifier<CompoundType>()(_r1) [
+				_a = _1,
+				_pass = (*_1 <= _r2)
 			]
-			>> '{')
-			>> ((
+			> '{')
+			> ((
 				r_name() [
-					_pass = phoenix::bind(&CompoundType::has_field, *_a, _1),
-					_b = static_cast_<string>(
-						phoenix::bind(&CompoundType::field_type<Type>, _a, _1)
-					)
+					_b = _1,
+					_pass = phoenix::bind(&CompoundType::has_field, *_a, _1)
 				]
-				>> '=' >> typed_expression()(_r1, _b)
-			) % ',') >> '}'
+				> '='
+				> typed_expression()(
+					_r1,
+					phoenix::bind(&CompoundType::field_type<Type>, *_a, _b)
+				)
+			) % ',') > '}'
 		) [
-			_val = new_<CompoundExpression>(
-				static_cast_<string>(*_a),
-				_2
-			)
+			_val = new_<CompoundExpression>(*_a, _2)
 		]
 		, "braced_compound_expression"
 	;

--- a/src/parser/compound_expression.h
+++ b/src/parser/compound_expression.h
@@ -26,9 +26,9 @@ namespace gologpp {
 namespace parser {
 
 
-extern rule<Expression *(Scope &)> compound_atom;
+extern rule<Expression *(Scope &, const Type &)> compound_atom;
 
-extern rule<Expression *(Scope &)> compound_expression;
+extern rule<Expression *(Scope &, const Type &)> compound_expression;
 
 
 void initialize_compound_exprs();

--- a/src/parser/domain.h
+++ b/src/parser/domain.h
@@ -25,21 +25,20 @@
 namespace gologpp {
 namespace parser {
 
-struct DomainExpressionParser : grammar<Domain(Scope &, Typename, bool)> {
+struct DomainExpressionParser : grammar<Domain(Scope &, const Type &, bool)> {
 	DomainExpressionParser();
 
-	rule<Domain(Scope &, Typename, bool)> domain_expr;
+	rule<Domain(Scope &, const Type &, bool)> domain_expr;
 	rule <
-		Domain(Scope &, Typename, bool),
+		Domain(Scope &, const Type &, bool),
 		locals<shared_ptr<Domain>>
 	> unary_domain_expr;
-	rule<Domain(Scope &, Typename, bool)> binary_domain_expr;
+	rule<Domain(Scope &, const Type &, bool)> binary_domain_expr;
 	rule<DomainOperator()> domain_operator;
 };
 
-rule<Domain(Scope &, Typename)> &domain_expression();
-rule<void(Scope &), locals<string, Typename>> &domain_decl();
-rule<void(Scope &, bool), locals<Typename>> &domain_assignment();
+rule<Domain(Scope &, const Type &)> &domain_expression();
+rule<void(Scope &), locals<string, shared_ptr<const Type>>> &domain_decl();
 
 
 } // namespace parser

--- a/src/parser/effect_axiom.cpp
+++ b/src/parser/effect_axiom.cpp
@@ -38,6 +38,7 @@
 #include "reference.h"
 #include "mixed_member_access.h"
 #include "expressions.h"
+#include "types.h"
 
 
 namespace gologpp {
@@ -51,9 +52,9 @@ EffectParser<LhsT>::EffectParser()
 	effect = (
 		(-(lit("if") > '(' > condition(_r1) > ')')
 		>> lhs(_r1) [
-			_a = phoenix::bind(&Expression::type_name, *_1)
+			_a = phoenix::bind(&Expression::type_ptr, *_1)
 		])
-		> '=' > typed_expression()(_r1, _a)
+		> '=' > typed_expression()(_r1, *_a)
 	) [
 		_val = new_<EffectAxiom<LhsT>>(),
 		phoenix::bind(&EffectAxiom<LhsT>::define, *_val, at_c<0>(_1), at_c<1>(_1), _2)
@@ -79,7 +80,7 @@ void EffectParser<Reference<Fluent>>::init()
 template<>
 void EffectParser<FieldAccess>::init()
 {
-	lhs = mixed_member_access()(_r1, UndefinedType::name()) [
+	lhs = mixed_member_access()(_r1, undefined_type()) [
 		_pass = (_val = dynamic_cast_<FieldAccess *>(_1))
 	];
 	lhs.name("field_access_effect_lhs");
@@ -89,7 +90,7 @@ void EffectParser<FieldAccess>::init()
 template<>
 void EffectParser<ListAccess>::init()
 {
-	lhs = mixed_member_access()(_r1, UndefinedType::name()) [
+	lhs = mixed_member_access()(_r1, undefined_type()) [
 		_pass = (_val = dynamic_cast_<ListAccess *>(_1))
 	];
 	lhs.name("list_access_effect_lhs");

--- a/src/parser/effect_axiom.h
+++ b/src/parser/effect_axiom.h
@@ -28,12 +28,12 @@ namespace parser {
 
 
 template<class LhsT>
-struct EffectParser : grammar<EffectAxiom<LhsT> *(Scope &), locals<Typename>> {
+struct EffectParser : grammar<EffectAxiom<LhsT> *(Scope &), locals<shared_ptr<const Type>>> {
 	EffectParser();
 
 	void init();
 
-	rule<EffectAxiom<LhsT> *(Scope &), locals<Typename>> effect;
+	rule<EffectAxiom<LhsT> *(Scope &), locals<shared_ptr<const Type>>> effect;
 	rule<LhsT *(Scope &)> lhs;
 	BooleanExpressionParser condition;
 };

--- a/src/parser/expressions.h
+++ b/src/parser/expressions.h
@@ -37,6 +37,8 @@ rule<Expression *(Scope &)> &value_expression();
 
 rule<Expression *(Scope &, Typename)> &typed_expression();
 
+extern rule<Conditional<Expression> *(Scope &, Typename)> conditional_expression;
+
 
 extern rule<Expression *(Scope &)> boolean_expression;
 extern rule<Expression *(Scope &)> numeric_expression;

--- a/src/parser/expressions.h
+++ b/src/parser/expressions.h
@@ -35,17 +35,17 @@ void initialize_cyclic_expressions();
 
 rule<Expression *(Scope &)> &value_expression();
 
-rule<Expression *(Scope &, Typename)> &typed_expression();
+rule<Expression *(Scope &, const Type &)> &typed_expression();
 
-extern rule<Conditional<Expression> *(Scope &, Typename)> conditional_expression;
+extern rule<Conditional<Expression> *(Scope &, const Type &)> conditional_expression;
 
 
 extern rule<Expression *(Scope &)> boolean_expression;
 extern rule<Expression *(Scope &)> numeric_expression;
 extern rule<Expression *(Scope &)> string_expression;
 extern rule<Expression *(Scope &)> symbolic_expression;
-extern rule<Expression *(Scope &)> compound_expression;
-extern rule<Expression *(Scope &)> list_expression;
+extern rule<Expression *(Scope &, const Type &)> compound_expression;
+extern rule<Expression *(Scope &, const Type &)> list_expression;
 
 
 

--- a/src/parser/fluent.h
+++ b/src/parser/fluent.h
@@ -32,7 +32,7 @@ struct FluentParser
 		Scope *,
 		string,
 		boost::optional < vector < shared_ptr < Variable > > >,
-		Typename
+		PType
 	>
 > {
 	FluentParser();
@@ -43,12 +43,12 @@ struct FluentParser
 			Scope *,
 			string,
 			boost::optional < vector < shared_ptr < Variable > > >,
-			Typename
+			PType
 		>
 	> fluent;
 
 	rule<Expression *(Scope &)> initial_val_arg;
-	rule<InitialValue *(Scope &, Typename)> initially;
+	rule<InitialValue *(Scope &, const Type &)> initially;
 };
 
 

--- a/src/parser/formula.cpp
+++ b/src/parser/formula.cpp
@@ -71,9 +71,9 @@ ComparisonParser::ComparisonParser()
 
 	comparison = (
 		(comparable_expr(_r1) >> cmp_op) [
-			_a = phoenix::bind(&Expression::type_name, *_1)
+			_a = phoenix::bind(&Expression::type_ptr, *_1)
 		]
-		> typed_expression()(_r1, _a)
+		> typed_expression()(_r1, *_a)
 	) [
 		_val = new_<Comparison>(at_c<0>(_1), at_c<1>(_1), _2)
 	];
@@ -151,10 +151,10 @@ BooleanExpressionParser::BooleanExpressionParser()
 
 	unary_expr = quantification(_r1) | negation(_r1) | boolean_value()
 		| bool_var_ref(_r1) | brace(_r1)
-		| mixed_member_access()(_r1, BoolType::name())
+		| mixed_member_access()(_r1, bool_type())
 		| comparison(_r1)
-		| typed_reference<Fluent>()(_r1, BoolType::name())
-		| typed_reference<Function>()(_r1, BoolType::name())
+		| typed_reference<Fluent>()(_r1, bool_type())
+		| typed_reference<Function>()(_r1, bool_type())
 	;
 	unary_expr.name("unary_boolean_expression");
 
@@ -196,7 +196,7 @@ BooleanExpressionParser::BooleanExpressionParser()
 	brace = '(' >> expression(_r1) >> ')';
 	brace.name("braced_boolean_expression");
 
-	bool_var_ref = var_usage()(_r1, val(BoolType::name())) [
+	bool_var_ref = var_usage()(_r1, bool_type()) [
 		_val = new_<Reference<Variable>>(_1)
 	];
 	bool_var_ref.name("reference_to_boolean_variable");

--- a/src/parser/formula.h
+++ b/src/parser/formula.h
@@ -27,10 +27,10 @@ namespace gologpp {
 namespace parser {
 
 
-struct ComparisonParser : grammar<Comparison *(Scope &), locals<Typename>> {
+struct ComparisonParser : grammar<Comparison *(Scope &), locals<shared_ptr<const Type>>> {
 	ComparisonParser();
 
-	rule<Comparison *(Scope &), locals<Typename>> comparison;
+	rule<Comparison *(Scope &), locals<shared_ptr<const Type>>> comparison;
 	rule<ComparisonOperator()> cmp_op;
 	rule<Expression *(Scope &)> comparable_expr;
 };

--- a/src/parser/functions.cpp
+++ b/src/parser/functions.cpp
@@ -48,12 +48,6 @@
 namespace gologpp {
 namespace parser {
 
-static rule<Typename(Scope &)> decl_prefix {
-	lit("procedure") [
-		_val = val(VoidType::name())
-	]
-	| any_type_specifier()(_r1) [ _val = _1 ] >> "function"
-};
 
 
 FunctionParser::FunctionParser()
@@ -61,7 +55,7 @@ FunctionParser::FunctionParser()
 {
 	function =
 		(
-			(any_type_specifier()(_r1) >> "function")
+			(type_identifier<Type>()(_r1) >> "function")
 			> r_name() > '('
 		) [
 			_a = new_<Scope>(_r1),
@@ -75,14 +69,14 @@ FunctionParser::FunctionParser()
 			lit(';') [
 				_val = phoenix::bind(
 					&Scope::declare_global<Function>,
-					_r1, _a, _d, _b, _c
+					_r1, _a, *_d, _b, _c
 				),
 				_pass = !!_val
 			]
-			| (lit('=') > typed_expression()(*_a, _d)) [
+			| (lit('=') > typed_expression()(*_a, *_d)) [
 				_val = phoenix::bind(
 					&Scope::define_global<Function, Expression *>,
-					_r1, _a, _d, _b, _c, _1
+					_r1, _a, *_d, _b, _c, _1
 				),
 				_pass = !!_val
 			]
@@ -90,7 +84,7 @@ FunctionParser::FunctionParser()
 	;
 	function.name("function_definition");
 	on_error<rethrow>(function, delete_(_a));
-	GOLOGPP_DEBUG_NODE(function);
+	GOLOGPP_DEBUG_NODE(function)
 }
 
 
@@ -110,14 +104,14 @@ ProcedureParser::ProcedureParser()
 			lit(';') [
 				_val = phoenix::bind(
 					&Scope::declare_global<Procedure>,
-					_r1, _a, VoidType::name(), _b, _c
+					_r1, _a, void_type(), _b, _c
 				),
 				_pass = !!_val
 			]
 			| statement(*_a) [
 				_val = phoenix::bind(
 					&Scope::define_global<Procedure, Instruction *>,
-					_r1, _a, VoidType::name(), _b, _c, _1
+					_r1, _a, void_type(), _b, _c, _1
 				),
 				_pass = !!_val
 			]
@@ -125,7 +119,7 @@ ProcedureParser::ProcedureParser()
 	;
 	procedure.name("function_definition");
 	on_error<rethrow>(procedure, delete_(_a));
-	GOLOGPP_DEBUG_NODE(procedure);
+	GOLOGPP_DEBUG_NODE(procedure)
 }
 
 

--- a/src/parser/functions.h
+++ b/src/parser/functions.h
@@ -33,7 +33,7 @@ struct FunctionParser
 		Scope *,
 		string,
 		boost::optional<vector<shared_ptr<Variable>>>,
-		string
+		shared_ptr<const Type>
 	>
 > {
 	FunctionParser();
@@ -44,7 +44,7 @@ struct FunctionParser
 			Scope *,
 			string,
 			boost::optional<vector<shared_ptr<Variable>>>,
-			string
+			shared_ptr<const Type>
 		>
 	> function;
 };
@@ -58,7 +58,7 @@ struct ProcedureParser
 		Scope *,
 		string,
 		boost::optional<vector<shared_ptr<Variable>>>,
-		string
+		shared_ptr<const Type>
 	>
 > {
 	ProcedureParser();
@@ -69,7 +69,7 @@ struct ProcedureParser
 			Scope *,
 			string,
 			boost::optional<vector<shared_ptr<Variable>>>,
-			string
+			shared_ptr<const Type>
 		>
 	> procedure;
 

--- a/src/parser/functions.h
+++ b/src/parser/functions.h
@@ -25,6 +25,7 @@ namespace gologpp {
 namespace parser {
 
 
+
 struct FunctionParser
 : grammar <
 	Function *(Scope &),
@@ -46,9 +47,35 @@ struct FunctionParser
 			string
 		>
 	> function;
+};
+
+
+
+struct ProcedureParser
+: grammar <
+	Procedure *(Scope &),
+	locals <
+		Scope *,
+		string,
+		boost::optional<vector<shared_ptr<Variable>>>,
+		string
+	>
+> {
+	ProcedureParser();
+
+	rule<
+		Procedure *(Scope &),
+		locals <
+			Scope *,
+			string,
+			boost::optional<vector<shared_ptr<Variable>>>,
+			string
+		>
+	> procedure;
 
 	StatementParser statement;
 };
+
 
 
 } // namespace parser

--- a/src/parser/grammar.h
+++ b/src/parser/grammar.h
@@ -25,18 +25,19 @@ namespace gologpp {
 namespace parser {
 
 
-struct ProgramParser : grammar<Expression *(Scope &)> {
-	ProgramParser()
-	: ProgramParser::base_type(program)
+struct BatParser : grammar<void(Scope &)> {
+	BatParser()
+	: BatParser::base_type(program)
 	{
-		program = +( omit[ // Discard attributes, they just register themselves as Globals
+		program = +(
 			fluent(_r1)
 			| action(_r1)
 			| exog_action(_r1)
 			| function(_r1)
+			| procedure(_r1)
 			| domain_decl()(_r1)
 			| type_definition(_r1)
-		] );
+		);
 
 		// The rules that parse all the different expression types have to be defined
 		// after all of the other high-level grammars have been initialized to break
@@ -44,14 +45,14 @@ struct ProgramParser : grammar<Expression *(Scope &)> {
 		initialize_cyclic_expressions();
 		initialize_cyclic_values();
 
-		GOLOGPP_DEBUG_NODE(program);
+		GOLOGPP_DEBUG_NODE(program)
 	}
 
-	rule<Expression *(Scope &)> program;
+	rule<void(Scope &)> program;
 	ActionParser<Action> action;
 	ActionParser<ExogAction> exog_action;
 	FunctionParser function;
-	StatementParser statement;
+	ProcedureParser procedure;
 	TypeDefinitionParser type_definition;
 	FluentParser fluent;
 };

--- a/src/parser/list_expression.cpp
+++ b/src/parser/list_expression.cpp
@@ -69,6 +69,7 @@ void initialize_list_exprs()
 
 	list_expression = {
 		mixed_member_access()(_r1, ListType::name()) [ _val = _1 ]
+			| conditional_expression(_r1, ListType::name()) [ _val = _1 ]
 			| list_atom(_r1) [ _val = _1 ]
 			| braced_list_expression(_r1) [ _val = _1 ]
 		, "list_expression"

--- a/src/parser/list_expression.h
+++ b/src/parser/list_expression.h
@@ -24,9 +24,9 @@ namespace gologpp {
 namespace parser {
 
 
-extern rule<Expression *(Scope &)> list_atom;
+extern rule<Expression *(Scope &, const Type &)> list_atom;
 
-extern rule<Expression *(Scope &)> list_expression;
+extern rule<Expression *(Scope &, const Type &)> list_expression;
 
 
 void initialize_list_exprs();

--- a/src/parser/mixed_member_access.cpp
+++ b/src/parser/mixed_member_access.cpp
@@ -59,7 +59,7 @@ rule<Expression *(Scope &, const Type &)> &mixed_member_access()
 {
 	static rule<Expression *(Scope &, const Type &), locals<Expression *>> rv_local {
 		(
-			(compound_atom(_r1, _r2) | list_atom(_r1, _r2)) [ _a = _1 ]
+			(compound_atom(_r1, undefined_type()) | list_atom(_r1, undefined_type())) [ _a = _1 ]
 			>> +(
 				field_access [ _a = new_<FieldAccess>(_a, _1) ]
 				| list_access(_r1) [ _a = new_<ListAccess>(_a, _1) ]

--- a/src/parser/mixed_member_access.cpp
+++ b/src/parser/mixed_member_access.cpp
@@ -55,24 +55,24 @@ static rule<Expression *(Scope &)> list_access {
 };
 
 
-rule<Expression *(Scope &, Typename)> &mixed_member_access()
+rule<Expression *(Scope &, const Type &)> &mixed_member_access()
 {
-	static rule<Expression *(Scope &, Typename), locals<Expression *>> rv_local {
+	static rule<Expression *(Scope &, const Type &), locals<Expression *>> rv_local {
 		(
-			(compound_atom(_r1) | list_atom(_r1)) [ _a = _1 ]
+			(compound_atom(_r1, _r2) | list_atom(_r1, _r2)) [ _a = _1 ]
 			>> +(
 				field_access [ _a = new_<FieldAccess>(_a, _1) ]
 				| list_access(_r1) [ _a = new_<ListAccess>(_a, _1) ]
 			)
 		) [
 			_val = _a,
-			_pass = (phoenix::bind(&AbstractLanguageElement::type, *_val) == _r2)
+			_pass = (phoenix::bind(&AbstractLanguageElement::type, *_val) <= _r2)
 		]
 		, "mixed_member_access"
 	};
 	GOLOGPP_DEBUG_NODE(rv_local)
 
-	static rule<Expression *(Scope &, Typename)> rv { rv_local(_r1, _r2) };
+	static rule<Expression *(Scope &, const Type &)> rv { rv_local(_r1, _r2) };
 	return rv;
 }
 

--- a/src/parser/mixed_member_access.h
+++ b/src/parser/mixed_member_access.h
@@ -24,7 +24,7 @@ namespace gologpp {
 namespace parser {
 
 
-rule<Expression *(Scope &, Typename)> &mixed_member_access();
+rule<Expression *(Scope &, const Type &)> &mixed_member_access();
 
 
 } // namespace parser

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -25,9 +25,9 @@ namespace gologpp {
 namespace parser {
 
 
-unique_ptr<Expression> parse_string(rule<Expression *(Scope &)> &parser, const std::string &code);
+unique_ptr<Instruction> parse_string(rule<Instruction *(Scope &)> &parser, const std::string &code);
 
-unique_ptr<Expression> parse_file(const std::string &filename);
+unique_ptr<Instruction> parse_file(const std::string &filename);
 
 
 } // namespace parser

--- a/src/parser/reference.cpp
+++ b/src/parser/reference.cpp
@@ -89,7 +89,7 @@ template struct ReferenceParser<Fluent>;
 
 template<class GologT>
 Reference<GologT> *get_typed_ref(
-	const string &type,
+	const Type &type,
 	const string &name,
 	const boost::optional<vector<Expression *>> &args
 ) {
@@ -98,7 +98,7 @@ Reference<GologT> *get_typed_ref(
 		static_cast<arity_t>(args.get_value_or({}).size())
 	);
 
-	if (g && g->type() == type)
+	if (g && g->type() <= type)
 		return new Reference<GologT>(name, args);
 	else
 		return nullptr;
@@ -107,9 +107,9 @@ Reference<GologT> *get_typed_ref(
 
 
 template<class GologT>
-rule<Reference<GologT> *(Scope &, Typename)> &typed_reference()
+rule<Reference<GologT> *(Scope &, const Type &)> &typed_reference()
 {
-	static rule<Reference<GologT> *(Scope &, Typename)> rv {
+	static rule<Reference<GologT> *(Scope &, const Type &)> rv {
 		(((r_name() >> "(") >> -(
 			value_expression()(_r1) %  ","
 		) ) >> ")") [
@@ -127,10 +127,10 @@ rule<Reference<GologT> *(Scope &, Typename)> &typed_reference()
 
 
 template
-rule<Reference<Fluent> *(Scope &, Typename)> &typed_reference();
+rule<Reference<Fluent> *(Scope &, const Type &)> &typed_reference();
 
 template
-rule<Reference<Function> *(Scope &, Typename)> &typed_reference();
+rule<Reference<Function> *(Scope &, const Type &)> &typed_reference();
 
 
 

--- a/src/parser/reference.cpp
+++ b/src/parser/reference.cpp
@@ -82,6 +82,7 @@ ReferenceParser<GologT>::ReferenceParser()
 template struct ReferenceParser<Action>;
 template struct ReferenceParser<ExogAction>;
 template struct ReferenceParser<Function>;
+template struct ReferenceParser<Procedure>;
 template struct ReferenceParser<Fluent>;
 
 

--- a/src/parser/reference.h
+++ b/src/parser/reference.h
@@ -38,7 +38,7 @@ struct ReferenceParser : grammar<Reference<GologT> *(Scope &)> {
 
 
 template<class GologT>
-rule<Reference<GologT> *(Scope &, Typename)> &typed_reference();
+rule<Reference<GologT> *(Scope &, const Type &)> &typed_reference();
 
 
 

--- a/src/parser/statements.cpp
+++ b/src/parser/statements.cpp
@@ -68,8 +68,8 @@ StatementParser::StatementParser()
 		| action_call(_r1)
 		| list_pop(_r1)
 		| list_push(_r1)
-		| typed_reference<Function>()(_r1, VoidType::name()))
-		> ';';
+		| procedure_call(_r1)
+	) > ';';
 	simple_statement.name("simple_statement");
 
 	compound_statement = block(_r1) | choose(_r1) | conditional(_r1)
@@ -105,7 +105,7 @@ StatementParser::StatementParser()
 			| empty_statement(_r1)
 		)
 	) [
-		_val = new_<Conditional>(_1, _2, _3)
+		_val = new_<Conditional<Instruction>>(_1, _2, _3)
 	];
 	conditional.name("conditional");
 
@@ -123,7 +123,7 @@ StatementParser::StatementParser()
 	];
 	pick.name("pick");
 
-	empty_statement = qi::attr(new_<Block>(new_<Scope>(_r1), construct<vector<Expression *>>()));
+	empty_statement = qi::attr(new_<Block>(new_<Scope>(_r1), construct<vector<Instruction *>>()));
 	empty_statement.name("empty_statement");
 
 	search = (lit("search") > statement(_r1)) [

--- a/src/parser/statements.h
+++ b/src/parser/statements.h
@@ -48,7 +48,7 @@ struct StatementParser : grammar<Instruction *(Scope &)> {
 	rule<Concurrent *(Scope &), locals<Scope *>> concurrent;
 
 	rule<ListPop *(Scope &), locals<ListOpEnd>> list_pop;
-	rule<ListPush *(Scope &), locals<ListOpEnd, Typename>> list_push;
+	rule<ListPush *(Scope &), locals<ListOpEnd, shared_ptr<const Type>>> list_push;
 
 	rule<During *(Scope &)> during;
 

--- a/src/parser/statements.h
+++ b/src/parser/statements.h
@@ -30,15 +30,15 @@ namespace parser {
 
 
 
-struct StatementParser : grammar<Expression *(Scope &)> {
+struct StatementParser : grammar<Instruction *(Scope &)> {
 	StatementParser();
 
-	rule<Expression *(Scope &)> statement;
-	rule<Expression *(Scope &)> simple_statement;
-	rule<Expression *(Scope &)> compound_statement;
+	rule<Instruction *(Scope &)> statement;
+	rule<Instruction *(Scope &)> simple_statement;
+	rule<Instruction *(Scope &)> compound_statement;
 	rule<Block *(Scope &), locals<Scope *>> block;
 	rule<Choose *(Scope &), locals<Scope *>> choose;
-	rule<Conditional *(Scope &)> conditional;
+	rule<Conditional<Instruction> *(Scope &)> conditional;
 	rule<Pick *(Scope &), locals<Scope *, shared_ptr<Variable>>> pick;
 
 	rule<Search *(Scope &)> search;
@@ -52,11 +52,12 @@ struct StatementParser : grammar<Expression *(Scope &)> {
 
 	rule<During *(Scope &)> during;
 
-	rule<Expression *(Scope &)> empty_statement;
+	rule<Instruction *(Scope &)> empty_statement;
 
 	rule<Return *(Scope &)> return_stmt;
 
 	ReferenceParser<Action> action_call;
+	ReferenceParser<Procedure> procedure_call;
 	rule<DurativeCall *(Scope &), locals<DurativeCall::Hook>> durative_call;
 
 	AssignmentParser<Reference<Fluent>> fluent_assignment;

--- a/src/parser/string_expression.cpp
+++ b/src/parser/string_expression.cpp
@@ -55,14 +55,14 @@ StringExpressionParser::StringExpressionParser()
 	unary_expr =
 		conversion(_r1)
 		| string_value() | var_ref(_r1)
-		| conditional_expression(_r1, StringType::name())
-		| typed_reference<Fluent>()(_r1, StringType::name())
-		| typed_reference<Function>()(_r1, StringType::name())
-		| mixed_member_access()(_r1, StringType::name())
+		| conditional_expression(_r1, string_type())
+		| typed_reference<Fluent>()(_r1, string_type())
+		| typed_reference<Function>()(_r1, string_type())
+		| mixed_member_access()(_r1, string_type())
 	;
 	unary_expr.name("unary_string_expression");
 
-	var_ref = var_usage()(_r1, val(StringType::name())) [
+	var_ref = var_usage()(_r1, string_type()) [
 		_val = new_<Reference<Variable>>(_1)
 	];
 	var_ref.name("reference_to_string_variable");

--- a/src/parser/string_expression.cpp
+++ b/src/parser/string_expression.cpp
@@ -55,6 +55,7 @@ StringExpressionParser::StringExpressionParser()
 	unary_expr =
 		conversion(_r1)
 		| string_value() | var_ref(_r1)
+		| conditional_expression(_r1, StringType::name())
 		| typed_reference<Fluent>()(_r1, StringType::name())
 		| typed_reference<Function>()(_r1, StringType::name())
 		| mixed_member_access()(_r1, StringType::name())

--- a/src/parser/symbolic_expression.cpp
+++ b/src/parser/symbolic_expression.cpp
@@ -42,14 +42,14 @@ SymbolicExpressionParser::SymbolicExpressionParser()
 {
 	expression = symbolic_value()
 		| var_ref(_r1)
-		| conditional_expression(_r1, SymbolType::name())
-		| typed_reference<Fluent>()(_r1, SymbolType::name())
-		| typed_reference<Function>()(_r1, SymbolType::name())
-		| mixed_member_access()(_r1, SymbolType::name())
+		| conditional_expression(_r1, symbol_type())
+		| typed_reference<Fluent>()(_r1, symbol_type())
+		| typed_reference<Function>()(_r1, symbol_type())
+		| mixed_member_access()(_r1, symbol_type())
 	;
 	expression.name("symbolic_expression");
 
-	var_ref = var_usage()(_r1, val(SymbolType::name())) [
+	var_ref = var_usage()(_r1, symbol_type()) [
 		_val = new_<Reference<Variable>>(_1)
 	];
 	var_ref.name("reference_to_symbolic_variable");

--- a/src/parser/symbolic_expression.cpp
+++ b/src/parser/symbolic_expression.cpp
@@ -20,6 +20,7 @@
 #include "value.h"
 #include "mixed_member_access.h"
 #include "reference.h"
+#include "expressions.h"
 
 #include <model/fluent.h>
 #include <model/procedural.h>
@@ -41,6 +42,7 @@ SymbolicExpressionParser::SymbolicExpressionParser()
 {
 	expression = symbolic_value()
 		| var_ref(_r1)
+		| conditional_expression(_r1, SymbolType::name())
 		| typed_reference<Fluent>()(_r1, SymbolType::name())
 		| typed_reference<Function>()(_r1, SymbolType::name())
 		| mixed_member_access()(_r1, SymbolType::name())

--- a/src/parser/types.cpp
+++ b/src/parser/types.cpp
@@ -65,8 +65,8 @@ void TypeNameParser<BaseT>::init()
 	non_list_type_name = r_name() [
 		_val = phoenix::bind(&Scope::lookup_type<BaseT>, _r1, _1),
 		_pass = !!_val
-	]
-	, "non_list_type_name";
+	];
+	non_list_type_name.name("non_list_type_name");
 
 	//GOLOGPP_DEBUG_NODES((type_name)(list_type_name))
 }

--- a/src/parser/utilities.h
+++ b/src/parser/utilities.h
@@ -43,9 +43,6 @@ using namespace boost::spirit::qi::labels;
 using namespace boost::phoenix;
 
 
-using Typename = string;
-
-
 /******************
 * Little helpers
 ******************/

--- a/src/parser/value.h
+++ b/src/parser/value.h
@@ -37,7 +37,7 @@ rule<Value *()> &undefined_value();
 
 rule<Value *()> &any_value();
 
-rule<Value *(Typename, bool)> &value();
+rule<Value *(const Type &, bool)> &value();
 
 
 void initialize_cyclic_values();

--- a/src/parser/variable.cpp
+++ b/src/parser/variable.cpp
@@ -40,11 +40,11 @@ namespace parser {
 
 rule<shared_ptr<Variable>(Scope &)> &var_decl() {
 	static rule<shared_ptr<Variable>(Scope &)> rv {
-		(any_type_specifier()(_r1) >> r_name()) [
+		(type_identifier<Type>()(_r1) >> r_name()) [
 			_val = phoenix::bind(
 				&Scope::get_var, _r1,
 				VarDefinitionMode::FORCE,
-				_1, _2
+				*_1, _2
 			)
 		],
 		"variable_declaration"
@@ -54,8 +54,8 @@ rule<shared_ptr<Variable>(Scope &)> &var_decl() {
 }
 
 
-rule<shared_ptr<Variable>(Scope &, Typename)> &var_usage() {
-	static rule<shared_ptr<Variable>(Scope &, Typename)> rv {
+rule<shared_ptr<Variable>(Scope &, const Type &)> &var_usage() {
+	static rule<shared_ptr<Variable>(Scope &, const Type &)> rv {
 		r_name() [
 			_val = phoenix::bind(
 				&Scope::get_var, _r1,
@@ -71,8 +71,8 @@ rule<shared_ptr<Variable>(Scope &, Typename)> &var_usage() {
 }
 
 
-rule<Reference<Variable> *(Scope &, Typename)> &var_ref() {
-	static rule<Reference<Variable> *(Scope &, Typename)> rv {
+rule<Reference<Variable> *(Scope &, const Type &)> &var_ref() {
+	static rule<Reference<Variable> *(Scope &, const Type &)> rv {
 		var_usage()(_r1, _r2) [
 			_val = new_<Reference<Variable>>(_1)
 		]

--- a/src/parser/variable.h
+++ b/src/parser/variable.h
@@ -27,8 +27,8 @@ namespace parser {
 
 
 rule<shared_ptr<Variable>(Scope &)> &var_decl();
-rule<shared_ptr<Variable>(Scope &, Typename)> &var_usage();
-rule<Reference<Variable> *(Scope &, Typename)> &var_ref();
+rule<shared_ptr<Variable>(Scope &, const Type &)> &var_usage();
+rule<Reference<Variable> *(Scope &, const Type &)> &var_ref();
 rule<shared_ptr<Variable>(Scope &)> &any_var_usage();
 
 

--- a/src/semantics/readylog/boilerplate.pl
+++ b/src/semantics/readylog/boilerplate.pl
@@ -16,6 +16,10 @@ function(to_string(V), R,
 	and(sprintf(S, "%w", V), atom_string(R, S))
 ).
 
+% Yet another wrapper to fix ReadyLog's broken function design
+% This is then a conditional that can actually be subf'ed recursively.
+function(func_if(Cond, V1, V2), R, lif(Cond, R = V1, R = V2)).
+
 
 function(gpp_field_value(Name, Compound), Value,
 	once(pl_field_value(Name, Compound, Value))

--- a/src/semantics/readylog/compound_expression.cpp
+++ b/src/semantics/readylog/compound_expression.cpp
@@ -36,7 +36,7 @@ EC_word Semantics<CompoundExpression>::plterm()
 			field_list
 		);
 	return ::term(EC_functor("gpp_compound", 2),
-		EC_atom(("#" + element().type_name()).c_str()),
+		EC_atom(("#" + element().type().name()).c_str()),
 		field_list
 	);
 }

--- a/src/semantics/readylog/execution.cpp
+++ b/src/semantics/readylog/execution.cpp
@@ -141,14 +141,17 @@ void ReadylogContext::compile(const AbstractAction &aa)
 
 void ReadylogContext::compile(const Fluent &fluent)
 {
-	compile_term(fluent.semantics<Fluent>().prim_fluent());
-	for (EC_word &initially : fluent.semantics<Fluent>().initially())
+	compile_term(fluent.semantics().prim_fluent());
+	for (EC_word &initially : fluent.semantics().initially())
 		compile_term(initially);
 }
 
 
 void ReadylogContext::compile(const Function &function)
-{ compile_term(function.semantics<Function>().definition()); }
+{ compile_term(function.semantics().definition()); }
+
+void ReadylogContext::compile(const Procedure &proc)
+{ compile_term(proc.semantics().definition()); }
 
 
 void ReadylogContext::compile_term(const EC_word &term)

--- a/src/semantics/readylog/execution.h
+++ b/src/semantics/readylog/execution.h
@@ -47,6 +47,7 @@ public:
 	virtual void compile(const AbstractAction &action) override;
 	virtual void compile(const Fluent &fluent) override;
 	virtual void compile(const Function &function) override;
+	virtual void compile(const Procedure &proc) override;
 	virtual void postcompile() override;
 
     virtual bool final(Block &program, History &history) override;

--- a/src/semantics/readylog/procedural.cpp
+++ b/src/semantics/readylog/procedural.cpp
@@ -320,7 +320,7 @@ EC_word Semantics<Return>::plterm() {
 	if (!function)
 	throw Bug(element().str() + " outside of function");
 
-	if (function->type() != element().expression().type())
+	if ((function->type() >= element().expression().type()))
 		throw ExpressionTypeMismatch(*function, element().expression());
 
 	if (element().expression().type().is<BoolType>())

--- a/src/semantics/readylog/procedural.cpp
+++ b/src/semantics/readylog/procedural.cpp
@@ -41,7 +41,7 @@ EC_word Semantics<Function>::plterm()
 
 EC_word Semantics<Function>::definition()
 {
-	if (element().type().is<VoidType>() || element().type().is<BoolType>()) {
+	if (element().type().is<BoolType>()) {
 		element().scope().semantics().init_vars();
 		return ::term(EC_functor("proc", 2),
 			plterm(),
@@ -55,10 +55,38 @@ EC_word Semantics<Function>::definition()
 		return ::term(EC_functor("function", 3),
 			plterm(),
 			return_var_,
-			element().definition().semantics().plterm()
+			::term(EC_functor("=", 2),
+				return_var_,
+				element().definition().semantics().plterm()
+			)
 		);
 	}
 }
+
+
+
+EC_word Semantics<Procedure>::plterm()
+{
+	if (element().arity() > 0)
+		return ::term(EC_functor(element().name().c_str(), element().arity()),
+			to_ec_words(element().params()).data()
+		);
+	else
+		return EC_atom(element().name().c_str());
+}
+
+
+EC_word Semantics<Procedure>::definition()
+{
+	element().scope().semantics().init_vars();
+	return ::term(EC_functor("proc", 2),
+		plterm(),
+		element().definition().semantics().plterm()
+	);
+}
+
+
+
 
 
 EC_word Semantics<Function>::return_var()
@@ -110,27 +138,28 @@ EC_word Semantics<Choose>::plterm()
 
 
 
-EC_word Semantics<Conditional>::plterm()
+template<>
+EC_word Semantics<Conditional<Instruction>>::plterm()
 {
-	EC_functor fn("if", 3);
-
-	const AbstractLanguageElement *parent = element().parent();
-	while (parent) {
-		if (parent->is_a<Global>()) {
-			if (parent->is_a<Function>() && !parent->type().is<VoidType>())
-				// An actual ReadyLog function (not a procedure): have to use lif/3
-				fn = EC_functor("lif", 3);
-
-			break;
-		}
-		parent = dynamic_cast<const Expression *>(parent)->parent();
-	}
-	return ::term(fn,
+	return ::term(EC_functor("if", 3),
 		element().condition().semantics().plterm(),
 		element().block_true().semantics().plterm(),
 		element().block_false().semantics().plterm()
 	);
 }
+
+
+template<>
+EC_word Semantics<Conditional<Expression>>::plterm()
+{
+	return ::term(EC_functor("func_if", 3),
+		element().condition().semantics().plterm(),
+		element().block_true().semantics().plterm(),
+		element().block_false().semantics().plterm()
+	);
+}
+
+
 
 
 

--- a/src/semantics/readylog/procedural.h
+++ b/src/semantics/readylog/procedural.h
@@ -58,6 +58,19 @@ private:
 
 
 template<>
+class Semantics<Procedure>
+: public Semantics<AbstractLanguageElement>
+, public AbstractSemantics<Procedure>
+{
+public:
+	using AbstractSemantics<Procedure>::AbstractSemantics;
+	virtual EC_word plterm() override;
+	virtual EC_word definition();
+};
+
+
+
+template<>
 class Semantics<Block>
 : public Semantics<AbstractLanguageElement>
 , public AbstractSemantics<Block>
@@ -86,13 +99,13 @@ public:
 
 
 
-template<>
-class Semantics<Conditional>
+template<class SignT>
+class Semantics<Conditional<SignT>>
 : public Semantics<AbstractLanguageElement>
-, public AbstractSemantics<Conditional>
+, public AbstractSemantics<Conditional<SignT>>
 {
 public:
-	using AbstractSemantics<Conditional>::AbstractSemantics;
+	using AbstractSemantics<Conditional<SignT>>::AbstractSemantics;
 	virtual EC_word plterm() override;
 };
 

--- a/src/semantics/readylog/reference.h
+++ b/src/semantics/readylog/reference.h
@@ -67,7 +67,7 @@ EC_word reference_term(const ReferenceBase<GologT, ExprT> &ref)
 template<class TargetT>
 class Semantics<Reference<TargetT>>
 : public AbstractSemantics<Reference<TargetT>>
-, public Semantics<Expression>
+, public Semantics<typename TargetT::SignifierT>
 {
 public:
 	using AbstractSemantics<Reference<TargetT>>::AbstractSemantics;

--- a/src/semantics/readylog/semantics.cpp
+++ b/src/semantics/readylog/semantics.cpp
@@ -66,6 +66,10 @@ Value Semantics<Expression>::evaluate(const Activity &context, const History &h)
 
 
 
+Instruction *Semantics<Instruction>::trans(History &)
+{ throw Bug("ReadylogSemantics doesn't implement Semantics<Instruction>::trans"); }
+
+
 #define GOLOGPP_DEFINE_MAKE_SEMANTICS_IMPL(_r, _data, GologT) \
 unique_ptr<AbstractSemantics<AbstractLanguageElement>> ReadylogSemanticsFactory::make_semantics(GologT &obj) \
 { return unique_ptr<AbstractSemantics<AbstractLanguageElement>>(new Semantics<GologT>(obj)); }

--- a/src/semantics/readylog/semantics.h
+++ b/src/semantics/readylog/semantics.h
@@ -48,6 +48,17 @@ public:
 };
 
 
+template<>
+class Semantics<Instruction>
+: public AbstractSemantics<Instruction>
+, public Semantics<AbstractLanguageElement>
+{
+public:
+	virtual ~Semantics<Instruction>() override = default;
+	virtual Instruction *trans(History &h) override;
+};
+
+
 #define GOLOGPP_DECL_MAKE_SEMANTICS_OVERRIDE(_r, _data, GologT) \
 	virtual unique_ptr<AbstractSemantics<AbstractLanguageElement>> make_semantics(GologT &) override;
 

--- a/src/tools/readylog-test.cpp
+++ b/src/tools/readylog-test.cpp
@@ -35,7 +35,7 @@ using namespace gologpp;
 
 void test_parser(const string &filename)
 {
-	Expression *mainproc = parser::parse_file(filename).release();
+	Instruction *mainproc = parser::parse_file(filename).release();
 
 	for (shared_ptr<const Global> g : global_scope().globals())
 		std::cout << g->str() << std::endl;


### PR DESCRIPTION
This PR makes domains first-class citizes of the type system. To keep things clean and consistent, it also comes with some syntactic changes:
- The `domain:` block is removed. All domains have to be defined explicitly and then be used as types.
- Functions have always been side-effect free, but the syntax (with `return` statements and curly-braced blocks) didn't make that obvious. Now, function bodies are pure expressions. There can be `if`/`else` branches, but they behave syntactically identical to the ternary `.. ? .. : ..` operator.

Type consistency checking has also become more strict. We now check for type subsumption, not equality.